### PR TITLE
feat: add 9 new skills and bump to v1.22.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "egandrade@gmail.com"
   },
   "metadata": {
-    "description": "46 universal AI skills for Claude Code — planning, orchestration, product strategy, career workflows, research, content processing, and document conversion"
+    "description": "55 universal AI skills for Claude Code — planning, orchestration, product strategy, career workflows, research, content processing, Obsidian knowledge management, and document conversion"
   },
   "plugins": [
     {
@@ -14,7 +14,7 @@
         "source": "github",
         "repo": "ericgandrade/claude-superskills"
       },
-      "description": "46 universal AI skills for Claude Code — planning, orchestration, product strategy, career workflows, research, content processing, and document conversion",
+      "description": "55 universal AI skills for Claude Code — planning, orchestration, product strategy, career workflows, research, content processing, Obsidian knowledge management, and document conversion",
       "author": {
         "name": "Eric Andrade"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-superskills",
-  "version": "1.21.8",
-  "description": "46 universal AI skills for Claude Code — skill creation, deep research, strategic planning, product management, content processing, document conversion, and orchestration workflows",
+  "version": "1.22.0",
+  "description": "55 universal AI skills for Claude Code — skill creation, deep research, strategic planning, product management, content processing, Obsidian knowledge management, and orchestration workflows",
   "author": {
     "name": "Eric Andrade",
     "url": "https://github.com/ericgandrade"

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1,7 +1,7 @@
 # 📚 Claude Superskills Catalog
 
-**Generated:** 2026-03-20T07:15:36.289858Z  
-**Total Skills:** 46  
+**Generated:** 2026-04-03T14:55:13.565225Z  
+**Total Skills:** 55  
 **Platforms:** GitHub Copilot CLI, Claude Code, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Cursor IDE, AdaL CLI
 
 ---
@@ -18,17 +18,25 @@
 | **audio-transcriber** | 2.1.0 | content | audio, transcription, whisper | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **brainstorming** | 2.0.0 | planning | brainstorming, design, requirements | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **career-changer-translator** | 2.1.0 | career | career-change, transferable-skills, career-pivot | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
-| **document-converter** | 1.0.0 | content | document-conversion, pdf, office, libreoffice, ocr, ghostscript, pdftk | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **cover-letter-generator** | 2.1.0 | career | cover-letter, job-application, resume | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **creative-portfolio-resume** | 2.1.0 | career | resume, creative, portfolio | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **deep-research** | 2.1.0 | research | research, search, analysis | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **docling-converter** | 2.1.0 | content | document-conversion, markdown, json | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
+| **document-converter** | 1.0.0 | content | document-conversion, pdf, office | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
+| **excalidraw-diagram** | 1.0.0 | Content / Visualization | excalidraw, diagram, whiteboard | Low | Claude Code GitHub Copilot All AI CLI tools |
 | **executing-plans** | 2.0.0 | planning | planning, execution, checkpoints | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **executive-resume-writer** | 2.1.0 | career | executive-resume, c-suite, vp | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **interview-prep-generator** | 2.1.0 | career | interview, star-stories, interview-prep | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **job-description-analyzer** | 2.1.0 | career | job-description, ats, keyword-extraction | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **linkedin-profile-optimizer** | 2.1.0 | career | linkedin, profile, recruiter | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **mckinsey-strategist** | 2.1.0 | strategy | consulting, strategy, mece | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
+| **mermaid-diagram** | 1.0.0 | Content / Visualization | mermaid, diagram, flowchart | Low | Claude Code GitHub Copilot All AI CLI tools |
+| **obsidian-automation** | 1.0.0 | Tools Needed | obsidian, automation, cli | Medium (file system operations) | Claude Code GitHub Copilot All AI CLI tools |
+| **obsidian-canvas** | 1.0.0 | Obsidian / Knowledge Management | obsidian, canvas, visual-workspace | Low | Claude Code GitHub Copilot All AI CLI tools |
+| **obsidian-frontmatter** | 1.0.0 | Obsidian / Knowledge Management | obsidian, frontmatter, yaml | Low | Claude Code GitHub Copilot All AI CLI tools |
+| **obsidian-links** | 1.0.0 | Obsidian / Knowledge Management | obsidian, wikilinks, knowledge-graph | Low | Claude Code GitHub Copilot All AI CLI tools |
+| **obsidian-markdown** | 1.0.0 | Obsidian | obsidian, markdown, wikilinks | Low | All 8 |
+| **obsidian-note-builder** | 1.0.0 | Obsidian / Knowledge Management | obsidian, note-building, zettelkasten | Low | Claude Code GitHub Copilot All AI CLI tools |
 | **offer-comparison-analyzer** | 2.1.0 | career | job-offer, compensation, equity | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **portfolio-case-study-writer** | 2.1.0 | career | portfolio, case-study, ux | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **pptx-translator** | 2.8.0 | content | translation, pptx, powerpoint | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
@@ -54,6 +62,7 @@
 | **storytelling-expert** | 2.0.0 | content | storytelling, narrative, presentations | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **tech-resume-optimizer** | 2.1.0 | career | resume, tech-resume, software-engineer | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **us-program-research** | 2.0.0 | research | us-programs, university-research, rankings | medium | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
+| **webpage-reader** | 1.0.0 | Content | web, extraction, markdown | Low | All 8 |
 | **writing-plans** | 2.0.0 | planning | planning, implementation-plan, task-breakdown | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 | **youtube-summarizer** | 2.1.0 | content | video, summarization, transcription | safe | GitHub Copilot CLI Claude Code OpenAI Codex OpenCode Gemini CLI Antigravity Cursor IDE AdaL CLI |
 
@@ -63,9 +72,49 @@
 
 ### Content
 
-- **document-converter** (v1.0.0)
-  - Description: This skill should be used when the user needs to convert documents between formats (Office to PDF, PDF to images, image to PDF), perform PDF operations (merge, split, rotate, encrypt, decrypt), or run OCR on scanned documents using local free tools.
-  - Tags: document-conversion, pdf, office, libreoffice, ocr, ghostscript, pdftk, imagemagick, tesseract
+- **webpage-reader** (v1.0.0)
+  - Description: This skill should be used when the user wants to read, fetch, extract, or analyze the content of a w...
+  - Tags: web, extraction, markdown, research, content, defuddle, url
+
+### Content / visualization
+
+- **excalidraw-diagram** (v1.0.0)
+  - Description: This skill should be used when the user needs to create a diagram using Excalidraw — a hand-drawn st...
+  - Tags: excalidraw, diagram, whiteboard, architecture, sketch, obsidian
+
+- **mermaid-diagram** (v1.0.0)
+  - Description: This skill should be used when the user needs to create, edit, or convert a diagram into Mermaid syn...
+  - Tags: mermaid, diagram, flowchart, sequence, visualization, obsidian
+
+### Obsidian
+
+- **obsidian-markdown** (v1.0.0)
+  - Description: This skill should be used when the user is working with Obsidian notes and needs to create or edit f...
+  - Tags: obsidian, markdown, wikilinks, callouts, frontmatter, embeds, vault
+
+### Obsidian / knowledge management
+
+- **obsidian-canvas** (v1.0.0)
+  - Description: This skill should be used when the user needs to create or edit an Obsidian Canvas — a freeform visu...
+  - Tags: obsidian, canvas, visual-workspace, knowledge-map, dashboard
+
+- **obsidian-frontmatter** (v1.0.0)
+  - Description: This skill should be used when the user needs to create, validate, standardize, or repair YAML front...
+  - Tags: obsidian, frontmatter, yaml, properties, metadata, dataview
+
+- **obsidian-links** (v1.0.0)
+  - Description: This skill should be used when the user needs to create, validate, repair, or analyze wikilinks insi...
+  - Tags: obsidian, wikilinks, knowledge-graph, backlinks, MOC
+
+- **obsidian-note-builder** (v1.0.0)
+  - Description: This skill should be used when the user wants to create a well-structured, richly linked Obsidian no...
+  - Tags: obsidian, note-building, zettelkasten, knowledge-graph, entity-extraction
+
+### Tools needed
+
+- **obsidian-automation** (v1.0.0)
+  - Description: This skill should be used when the user wants to automate repetitive Obsidian tasks using the Obsidi...
+  - Tags: obsidian, automation, cli, scripting, shell, batch-processing
 
 ### Architecture
 
@@ -170,6 +219,10 @@
 - **docling-converter** (v2.1.0)
   - Description: This skill should be used when the user needs to convert documents (PDF, DOCX, PPTX, XLSX, HTML, ima...
   - Tags: document-conversion, markdown, json, pdf, docling, ocr
+
+- **document-converter** (v1.0.0)
+  - Description: This skill should be used when the user needs to convert documents between formats (Office to PDF, P...
+  - Tags: document-conversion, pdf, office, libreoffice, ocr, ghostscript, pdftk, imagemagick, tesseract
 
 - **pptx-translator** (v2.8.0)
   - Description: This skill should be used when the user needs to translate PowerPoint presentations (.pptx) between ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.22.0] - 2026-04-03
+
+### Added
+
+- **webpage-reader skill**: extracts clean Markdown from URLs using the Defuddle CLI. Supports metadata-only mode, batch URL processing, and custom output paths.
+- **mermaid-diagram skill**: generates Mermaid diagram syntax (flowchart, sequence, class, state, ER, mindmap, Gantt, pie, quadrant) from plain-language descriptions. 12 diagram types supported.
+- **excalidraw-diagram skill**: creates hand-drawn style diagrams in Excalidraw JSON format. Supports architecture sketches, concept maps, user flows, C4 context diagrams, and org charts. Output embeds in Obsidian or opens at excalidraw.com.
+- **obsidian-markdown skill**: comprehensive Obsidian Flavored Markdown reference — wikilinks, embeds, callouts, frontmatter properties, block IDs, and all Obsidian-specific syntax extensions.
+- **obsidian-links skill**: creates, validates, repairs, and analyzes wikilinks in Obsidian vaults. Includes broken link detection, orphan discovery, auto-linking, and Map of Content builder.
+- **obsidian-frontmatter skill**: creates, validates, standardizes, and repairs YAML frontmatter properties in Obsidian notes. Covers tags, aliases, dates, custom properties, and Dataview-compatible schema.
+- **obsidian-automation skill**: automates Obsidian vault tasks using the Obsidian CLI (Local REST API), shell scripts, and Templater. Batch note creation, bulk frontmatter updates, vault maintenance, and integration with external tools.
+- **obsidian-note-builder skill**: builds complete, knowledge-graph-ready Obsidian notes from raw content. Extracts entities, inserts wikilinks, applies note templates (atomic, meeting, reference, project), and supports Zettelkasten atomicity.
+- **obsidian-canvas skill**: creates freeform visual workspaces using Obsidian Canvas JSON format. Supports hub-and-spoke, column, linear, and Kanban layout patterns. Output is a ready-to-save `.canvas` file.
+- **obsidian bundle**: new curated bundle containing `obsidian-markdown`, `obsidian-links`, `obsidian-frontmatter`, `obsidian-automation`, `obsidian-note-builder`, `obsidian-canvas`.
+- **content bundle**: extended with `webpage-reader`, `mermaid-diagram`, `excalidraw-diagram`.
+- **research bundle**: extended with `webpage-reader`.
+
+### Fixed
+
+- **validate-skill-yaml.sh**: fixed false positive when SKILL.md body contains YAML code examples (e.g., showing how to write frontmatter with `tags:`, `---` delimiters). Validator now uses `awk` to extract only the first frontmatter block, ignoring code examples in the body.
+
+---
+
 ## [1.21.8] - 2026-03-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **claude-superskills** is a reusable AI skills library for **8 AI platforms**: GitHub Copilot CLI, Claude Code, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Cursor IDE, and AdaL CLI. Skills are Markdown-based workflow specifications (`SKILL.md`) that teach AI agents how to perform specific tasks.
 
-- **npm package**: `claude-superskills` (v1.21.8) — `npx claude-superskills` — **46 skills**
+- **npm package**: `claude-superskills` (v1.22.0) — `npx claude-superskills` — **55 skills**
 - **Claude Code plugin**: `claude --plugin-dir ./claude-superskills` — native plugin, no npm needed
 - **GitHub**: `https://github.com/ericgandrade/claude-superskills`
 - **Old package** `cli-ai-skills` is deprecated, redirects to this one
@@ -115,7 +115,16 @@ claude-superskills/
 │   ├── us-program-research/
 │   ├── writing-plans/
 │   ├── youtube-summarizer/
-│   └── pptx-translator/
+│   ├── pptx-translator/
+│   ├── webpage-reader/
+│   ├── mermaid-diagram/
+│   ├── excalidraw-diagram/
+│   ├── obsidian-markdown/
+│   ├── obsidian-links/
+│   ├── obsidian-frontmatter/
+│   ├── obsidian-automation/
+│   ├── obsidian-note-builder/
+│   └── obsidian-canvas/
 │
 ├── cli-installer/             # NPM package (claude-superskills)
 │   ├── bin/cli.js            # Main CLI entry point (commands, flags, install flow)
@@ -262,7 +271,7 @@ npx claude-superskills
 /plugin install claude-superskills@claude-superskills
     → clones repo → copies to ~/.claude/plugins/cache/claude-superskills/
     → auto-discovers skills/ directory
-    → registers all 46 skills as /claude-superskills:<skill-name>
+    → registers all 55 skills as /claude-superskills:<skill-name>
 
 # NOTE: The shell command `claude plugin install ...` is currently unstable
 # due to upstream bugs in Claude Code (e.g. anthropics/claude-code#29722).
@@ -466,7 +475,7 @@ Skills that interact with project structure should include a discovery phase tha
 
 ## Version Management
 
-The package version is defined in `cli-installer/package.json` (currently **v1.21.8**).
+The package version is defined in `cli-installer/package.json` (currently **v1.22.0**).
 `.claude-plugin/plugin.json` `"version"` must always match `package.json` exactly.
 
 - `cli-installer/package.json` — source of truth for npm version
@@ -504,7 +513,7 @@ Do not skip any of these steps when bumping the version.
    # It must be updated whenever: skill count changes, MCP servers are added/removed,
    # supported platforms change, or the product positioning changes.
    # Failure to update it leaves stale metadata visible to all visitors.
-   gh repo edit --description "46 Universal AI Skills for Claude Code, GitHub Copilot & 6 more platforms. Planning, orchestration, product strategy, career workflows, research, document conversion — no API keys required."
+   gh repo edit --description "55 Universal AI Skills for Claude Code, GitHub Copilot & 6 more platforms. Planning, orchestration, product strategy, career workflows, research, Obsidian knowledge management, document conversion — no API keys required."
    gh repo edit --add-topic "claude-code,github-copilot,ai-skills,skills,prompt-engineering,product-strategy,career-development,cli,automation,generative-ai,agents,productivity,llm,anthropic,openai-codex,cursor-ide,gemini-cli,workflow-automation,tech-leadership,ats-optimization"
    ```
 6. **Generate Claude Desktop Plugin Package:**
@@ -587,7 +596,7 @@ Curated skill collections:
 - **content**: `youtube-summarizer`, `audio-transcriber`, `docling-converter`, `pptx-translator`
 - **developer**: `skill-creator`
 - **orchestration**: `agent-skill-discovery`, `agent-skill-orchestrator`
-- **all**: all 46 skills
+- **all**: all 55 skills
 
 ## Automation Scripts
 
@@ -607,9 +616,10 @@ Curated skill collections:
 - **Planning** — Pre-implementation design and execution (`brainstorming`, `writing-plans`, `executing-plans`)
 - **Product & Strategy** — Frameworks for product management, discovery, and GTM (`product-strategy`, `product-discovery`, `abx-strategy`, etc.)
 - **Research** — Deep research and academic analysis (`deep-research`, `us-program-research`)
-- **Content** — Media and document processing (`youtube-summarizer`, `audio-transcriber`, `docling-converter`, `document-converter`, `pptx-translator`)
+- **Content** — Media and document processing (`youtube-summarizer`, `audio-transcriber`, `docling-converter`, `document-converter`, `pptx-translator`, `webpage-reader`, `mermaid-diagram`, `excalidraw-diagram`)
 - **Architecture** — System design, C4 modeling, and ADRs (`senior-solution-architect`, `product-architecture`)
 - **Startup** — Market sizing, unit economics, and GTM for founders (`startup-growth-strategist`, `product-strategy`, `abx-strategy`)
+- **Obsidian** — Knowledge management, note building, wikilinks, frontmatter, automation, and visual workspaces (`obsidian-markdown`, `obsidian-links`, `obsidian-frontmatter`, `obsidian-automation`, `obsidian-note-builder`, `obsidian-canvas`)
 
 ### Orchestration Skills
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# 🤖 Claude Superskills v1.21.8
+# 🤖 Claude Superskills v1.22.0
 
 Scale AI-assisted engineering with a reusable skill platform that turns ad-hoc prompting into standardized, high-impact workflows. Install once and deliver consistent planning, research, orchestration, and content automation across your entire multi-tool AI stack.
 
-![Version](https://img.shields.io/badge/version-1.21.8-blue.svg)
+![Version](https://img.shields.io/badge/version-1.22.0-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
-![Skills](https://img.shields.io/badge/skills-46-brightgreen.svg)
+![Skills](https://img.shields.io/badge/skills-55-brightgreen.svg)
 ![Platforms](https://img.shields.io/badge/platforms-8-orange.svg)
 
 ## 🚀 Quick Install
@@ -160,7 +160,7 @@ Important:
 
 ---
 
-### Once installed — all 46 skills under the `claude-superskills:` namespace
+### Once installed — all 55 skills under the `claude-superskills:` namespace
 
 ```
 /claude-superskills:skill-creator
@@ -172,14 +172,14 @@ Important:
 /claude-superskills:executing-plans
 /claude-superskills:agent-skill-discovery
 /claude-superskills:agent-skill-orchestrator
-... (44 total)
+... (46 more)
 ```
 
 > **npm install still works** for GitHub Copilot, Cursor IDE, Gemini CLI, and 5 other platforms. The plugin format is Claude Code-specific.
 
 ## ✨ Features
 
-- **46 Universal Skills** - Work on all platforms
+- **55 Universal Skills** - Work on all platforms
 - **Zero-Config Install** - Run once, works everywhere
 - **Curated Bundles** - Install exactly what you need
 - **Smart Search** - Find skills by keyword
@@ -272,6 +272,19 @@ Important:
 | **document-converter** | v1.0.0 | Convert Office documents to PDF, perform PDF operations (merge, split, rotate, encrypt, OCR) using local free tools — LibreOffice, ghostscript, pdftk, tesseract, imagemagick |
 | **pptx-translator** | v2.8.0 | Translate PowerPoint presentations between languages with batched parallel translation (3 slides/batch), AI-native language classification, group shape support, per-slide self-validation, and interactive output filename choice (original + lang suffix, AI-translated name, or custom) |
 | **storytelling-expert** | v2.0.0 | Transform ideas into engaging narratives using 8 elite storytelling frameworks |
+| **webpage-reader** | v1.0.0 | Extract clean Markdown from any URL using the Defuddle CLI. Supports metadata-only mode, batch URLs, and saving output to file |
+| **mermaid-diagram** | v1.0.0 | Generate Mermaid diagram syntax from plain-language descriptions — flowchart, sequence, class, state, ER, mindmap, Gantt, and 5 more types |
+| **excalidraw-diagram** | v1.0.0 | Create hand-drawn style diagrams in Excalidraw JSON format — architecture sketches, concept maps, user flows, C4 context, org charts |
+
+### 🗒️ Obsidian Knowledge Management
+| Skill | Version | Purpose |
+|-------|---------|-------|
+| **obsidian-markdown** | v1.0.0 | Master Obsidian Flavored Markdown — wikilinks, embeds, callouts, frontmatter properties, block IDs, and all Obsidian-specific syntax extensions |
+| **obsidian-links** | v1.0.0 | Create, validate, repair, and analyze wikilinks in Obsidian vaults. Broken link detection, orphan discovery, auto-linking, and MOC builder |
+| **obsidian-frontmatter** | v1.0.0 | Create, validate, standardize, and repair YAML frontmatter properties — tags, aliases, dates, custom fields — for Dataview-compatible notes |
+| **obsidian-automation** | v1.0.0 | Automate Obsidian vault tasks using the CLI, shell scripts, and Local REST API — batch note creation, bulk updates, and vault maintenance |
+| **obsidian-note-builder** | v1.0.0 | Build complete, knowledge-graph-ready Obsidian notes from raw content with entity extraction, auto-wikilinks, and Zettelkasten atomicity |
+| **obsidian-canvas** | v1.0.0 | Create freeform visual workspaces using Obsidian Canvas — hub-and-spoke, Kanban, and dashboard layouts as ready-to-save `.canvas` files |
 
 ## 🎯 Curated Bundles
 
@@ -296,6 +309,9 @@ npx claude-superskills --bundle research -y
 
 # Skill Developer (for creating custom skills)
 npx claude-superskills --bundle developer -y
+
+# Obsidian Knowledge Management
+npx claude-superskills --bundle obsidian -y
 
 # All Skills (complete collection)
 npx claude-superskills --bundle all -y
@@ -441,7 +457,7 @@ MIT - See [LICENSE](./LICENSE) for details.
 
 **Built with ❤️ by [Eric Andrade](https://github.com/ericgandrade)**
 
-*Version 1.21.8 | March 2026*
+*Version 1.22.0 | April 2026*
 
 ## 🎁 Get Started
 
@@ -453,6 +469,7 @@ Choose a bundle that fits your workflow:
 - **[Product](docs/bundles/bundles.md#-product--strategy-bundle)** - abx-strategy, ai-native-product, product-strategy, and more
 - **[Career](docs/bundles/bundles.md#-career--professional-growth-bundle)** - resume-ats-optimizer, interview-prep, salary-negotiation, and more
 - **[Research](docs/bundles/bundles.md#-research--analysis-bundle)** - deep-research, us-program-research + discovery
+- **[Obsidian](docs/bundles/bundles.md#-obsidian-knowledge-management-bundle)** - obsidian-markdown, links, frontmatter, automation, note-builder, canvas
 - **[Developer](docs/bundles/bundles.md#-developer-bundle)** - skill-creator for power users
 - **[All](docs/bundles/bundles.md#-all-skills-bundle)** - Complete toolkit
 

--- a/bundles.json
+++ b/bundles.json
@@ -48,7 +48,8 @@
         "deep-research",
         "us-program-research",
         "agent-skill-discovery",
-        "prompt-engineer"
+        "prompt-engineer",
+        "webpage-reader"
       ],
       "use_cases": [
         "Technical due diligence",
@@ -68,7 +69,10 @@
         "docling-converter",
         "document-converter",
         "pptx-translator",
-        "storytelling-expert"
+        "storytelling-expert",
+        "webpage-reader",
+        "mermaid-diagram",
+        "excalidraw-diagram"
       ],
       "use_cases": [
         "Summarizing YouTube videos",
@@ -158,7 +162,16 @@
         "tech-resume-optimizer",
         "senior-solution-architect",
         "startup-growth-strategist",
-        "pptx-translator"
+        "pptx-translator",
+        "webpage-reader",
+        "mermaid-diagram",
+        "excalidraw-diagram",
+        "obsidian-markdown",
+        "obsidian-links",
+        "obsidian-frontmatter",
+        "obsidian-automation",
+        "obsidian-note-builder",
+        "obsidian-canvas"
       ],
       "use_cases": [
         "Complete AI assistance",
@@ -251,6 +264,26 @@
         "Launch strategy"
       ],
       "target": "Founders, Entrepreneurs, Business Analysts"
+    },
+    "obsidian": {
+      "name": "Obsidian Knowledge Management",
+      "description": "Complete toolkit for working with Obsidian vaults: notes, links, frontmatter, automation, canvas, and diagrams.",
+      "skills": [
+        "obsidian-markdown",
+        "obsidian-links",
+        "obsidian-frontmatter",
+        "obsidian-automation",
+        "obsidian-note-builder",
+        "obsidian-canvas"
+      ],
+      "use_cases": [
+        "Creating well-structured Obsidian notes",
+        "Managing wikilinks and knowledge graphs",
+        "Standardizing frontmatter properties",
+        "Automating vault tasks with CLI scripts",
+        "Building visual workspaces with Canvas"
+      ],
+      "target": "Obsidian users, knowledge workers, researchers"
     }
   }
 }

--- a/cli-installer/README.md
+++ b/cli-installer/README.md
@@ -1,10 +1,10 @@
-# claude-superskills v1.21.8
+# claude-superskills v1.22.0
 
-Universal installer for the `claude-superskills` library. Install 46 reusable AI skills across GitHub Copilot CLI, Claude Code, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Cursor IDE, and AdaL CLI from one command.
+Universal installer for the `claude-superskills` library. Install 55 reusable AI skills across GitHub Copilot CLI, Claude Code, OpenAI Codex, OpenCode, Gemini CLI, Antigravity, Cursor IDE, and AdaL CLI from one command.
 
 If Claude Desktop is detected, the installer can also generate a Claude Cowork plugin zip for manual upload.
 
-![Version](https://img.shields.io/badge/version-1.21.8-blue.svg)
+![Version](https://img.shields.io/badge/version-1.22.0-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Node](https://img.shields.io/badge/node-%3E%3D14.0.0-green.svg)
 
@@ -85,7 +85,7 @@ Support status:
 - `career` - Resume, job search, interview, negotiation, and portfolio workflows
 - `developer` - Skill creation workflows
 - `orchestration` - Resource discovery and planning
-- `all` - All 46 available skills
+- `all` - All 55 available skills
 
 ```bash
 npx claude-superskills --list-bundles

--- a/cli-installer/package.json
+++ b/cli-installer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-superskills",
-  "version": "1.21.8",
-  "description": "46 Reusable AI CLI skills for GitHub Copilot, Claude Code, and 6 more AI platforms",
+  "version": "1.22.0",
+  "description": "55 Reusable AI CLI skills for GitHub Copilot, Claude Code, and 6 more AI platforms",
   "main": "lib/index.js",
   "bin": {
     "claude-superskills": "bin/cli.js"

--- a/docs/bundles/bundles.md
+++ b/docs/bundles/bundles.md
@@ -46,12 +46,15 @@ npx claude-superskills --bundle essential -y
 
 ## 🎬 Content Creation Bundle
 
-**Perfect for:** Processing video and audio
+**Perfect for:** Processing video, audio, web pages, and diagrams
 
 **Includes:**
 - **youtube-summarizer** - Summarize YouTube videos
 - **audio-transcriber** - Transcribe audio to Markdown
 - **docling-converter** - Convert PDF/Office/image docs to Markdown/JSON with optional OCR
+- **webpage-reader** - Extract clean Markdown from any URL using Defuddle CLI
+- **mermaid-diagram** - Generate Mermaid diagrams from plain-language descriptions
+- **excalidraw-diagram** - Create hand-drawn style diagrams in Excalidraw JSON format
 
 **Installation:**
 ```bash
@@ -63,9 +66,11 @@ npx claude-superskills --bundle content -y
 - 🎙️ Transcribing podcasts and recordings
 - 📋 Creating meeting notes automatically
 - 📊 Extracting key insights from videos
+- 🌐 Reading and saving web page content as Markdown
+- 📐 Generating architecture and flow diagrams
 - 🌍 Multi-language support (99+ languages)
 
-**Word Count:** ~4000 words of functionality
+**Word Count:** ~10000 words of functionality
 
 **Perfect For:**
 - Content creators
@@ -73,6 +78,7 @@ npx claude-superskills --bundle content -y
 - Podcast producers
 - Meeting attendees
 - Students
+- Developers documenting systems
 
 ---
 
@@ -108,6 +114,7 @@ npx claude-superskills --bundle planning -y
 - **us-program-research** - US academic program ranking and action-plan workflow
 - **agent-skill-discovery** - Discover available resources
 - **prompt-engineer** - Improve research prompts
+- **webpage-reader** - Extract and save web content as clean Markdown
 
 **Installation:**
 ```bash
@@ -119,6 +126,7 @@ npx claude-superskills --bundle research -y
 - 📚 Literature and technical scans
 - 🧾 Decision support with cited evidence
 - 🧭 Repository and environment discovery
+- 🌐 Save reference pages as structured Markdown
 
 ---
 
@@ -151,23 +159,46 @@ npx claude-superskills --bundle developer -y
 
 ---
 
-## 🚀 All Skills Bundle
+## �️ Obsidian Knowledge Management Bundle {#-obsidian-knowledge-management-bundle}
 
-**Perfect for:** Complete functionality
+**Perfect for:** Obsidian vault users, knowledge workers, and researchers
 
 **Includes:**
-- **agent-skill-discovery** - Discover installed and local resources
-- **agent-skill-orchestrator** - Build intelligent execution strategies
-- **brainstorming** - Clarify design before coding
-- **writing-plans** - Create implementation plans
-- **executing-plans** - Execute plans with checkpoints
-- **deep-research** - Run deep research with citations
-- **skill-creator** - Create custom skills
-- **prompt-engineer** - Optimize prompts
-- **docling-converter** - Convert complex documents with Docling
-- **youtube-summarizer** - Summarize videos
-- **audio-transcriber** - Transcribe audio
-- **us-program-research** - Research and rank US academic programs
+- **obsidian-markdown** - Master Obsidian Flavored Markdown syntax (wikilinks, callouts, embeds, block IDs)
+- **obsidian-links** - Create, validate, repair, and analyze wikilinks across an Obsidian vault
+- **obsidian-frontmatter** - Create, validate, and standardize YAML properties for Dataview compatibility
+- **obsidian-automation** - Automate vault tasks using the CLI, shell scripts, and Local REST API
+- **obsidian-note-builder** - Build knowledge-graph-ready notes from raw content with Zettelkasten patterns
+- **obsidian-canvas** - Generate freeform visual workspaces as ready-to-save `.canvas` files
+
+**Installation:**
+```bash
+npx claude-superskills --bundle obsidian -y
+```
+
+**Use Cases:**
+- 📝 Creating well-structured Obsidian notes automatically
+- 🔗 Finding and fixing broken wikilinks across the vault
+- 🏷️ Standardizing frontmatter and tags for Dataview queries
+- ⚙️ Batch operations without manually touching each note
+- 🗺️ Building visual Maps of Content and dashboards
+- 🧠 Zettelkasten-style knowledge base maintenance
+
+**Perfect For:**
+- Obsidian users
+- Knowledge workers
+- Researchers
+- Note-taking enthusiasts
+- Teams using Obsidian as a shared knowledge base
+
+---
+
+## 🚀 All Skills Bundle
+
+**Perfect for:** Complete functionality — all 55 skills
+
+**Includes:** All 55 skills across every category:
+Career & Professional Growth · Discovery & Orchestration · Development & Automation · Planning & Execution · Software Architecture · Startup & Venture · Product Management · Research & Analysis · Content Processing · Obsidian Knowledge Management
 
 **Installation:**
 ```bash
@@ -176,12 +207,10 @@ npx claude-superskills --bundle all -y
 
 **Use Cases:**
 - 🎓 Complete learning experience
-- 🔄 All content types (prompts, video, audio)
+- 🔄 All content types (prompts, video, audio, web, diagrams)
 - 🛠️ Full development capability
 - 💼 Enterprise comprehensive suite
 - 🌟 Maximum AI assistance
-
-**Word Count:** ~9000 words of functionality
 
 **Perfect For:**
 - Power users
@@ -193,16 +222,18 @@ npx claude-superskills --bundle all -y
 
 ## 📊 Bundle Comparison
 
-| Feature | Essential | Content | Planning | Research | Developer | All |
-|---------|-----------|---------|----------|----------|-----------|-----|
-| Prompt Optimization | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Skill Creation | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
-| Video Summarization | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Audio Transcription | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
-| Planning Workflow | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
-| Deep Research | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
-| Skills Count | 7 | 3 | 4 | 4 | 1 | 12 |
-| Size | Medium | Medium | Medium | Small | Small | Large |
+| Feature | Essential | Content | Planning | Research | Obsidian | Developer | All |
+|---------|-----------|---------|----------|----------|----------|-----------|-----|
+| Prompt Optimization | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Skill Creation | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
+| Video/Audio | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Web Page Reader | ❌ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Diagrams | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Planning Workflow | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ |
+| Deep Research | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ✅ |
+| Obsidian Vault | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| Skills Count | 7 | 6 | 4 | 5 | 6 | 1 | 55 |
+| Size | Medium | Large | Medium | Medium | Medium | Small | Complete |
 
 ---
 

--- a/docs/plan/2026-04-03-gtm-consulting-skills-plan.md
+++ b/docs/plan/2026-04-03-gtm-consulting-skills-plan.md
@@ -1,0 +1,418 @@
+# GTM Consulting Skills — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add 2 new skills to claude-superskills focused on GTM for Microsoft consulting offers — ICP definition by account type and offer GTM design — filling a gap not covered by existing `abx-strategy`, `product-strategy`, or `startup-growth-strategist`.
+
+**Architecture:** Each skill follows the repository's single-source-of-truth model: `skills/<name>/SKILL.md` + `skills/<name>/README.md`. Minimal frontmatter (name, description, license only). No version bump until both skills are complete and validated. A third candidate skill (`presales-qualifier`) is scoped but deferred to a second batch after user review.
+
+**Tech Stack:** Markdown skill files, YAML frontmatter, repository validation scripts (`validate-skill-yaml.sh`, `validate-skill-content.sh`), Python index generators.
+
+**Context:** Eric Andrade, VP/Client Solutions Lead at Avanade Brazil, is responsible for creating and improving GTMs for Microsoft consulting offers (Assessment, System Integration, Outsourcing, Shared Services) targeting Enterprise accounts and SMC (Small, Medium, Corporate) segments per Microsoft's market segmentation.
+
+---
+
+## Pre-Implementation Checklist
+
+Before starting Task 1, verify:
+
+- [ ] Branch is `feature/obsidian-skills-plan` (reuse or create `feature/gtm-consulting-skills`)
+- [ ] `skills/` has no existing skill named `microsoft-consulting-icp` or `consulting-gtm-designer`
+- [ ] No overlap with `abx-strategy` (that skill targets generic B2B startups, not Microsoft partner consulting)
+- [ ] `docs/plan/` directory exists (not `docs/plans/` which is gitignored)
+
+---
+
+## Skill 1: `microsoft-consulting-icp`
+
+### Overview
+
+**Purpose:** Define Ideal Customer Profile for Microsoft consulting engagements, segmented by account type (Enterprise vs SMC) and offer type (Assessment, SI, Outsourcing, Shared Services). Includes buyer persona mapping per offer, PURE-based opportunity scoring adapted to the Microsoft/Avanade context, and explicit Anti-ICP to prevent low-quality pipeline.
+
+**Why not `abx-strategy`?** `abx-strategy` targets B2B companies with <500 accounts and generic SaaS/tech offers. `microsoft-consulting-icp` is specific to: Microsoft platform consulting, Avanade/partner ecosystem dynamics, Brazilian enterprise market segmentation (Enterprise vs SMC), and the buyer committee differences between a CIO buying an Assessment vs. a CFO approving a 3-year Outsourcing deal.
+
+**Trigger phrases:**
+- "Quem é meu ICP para Assessment no segmento Enterprise?"
+- "Qual é o perfil de conta ideal para Outsourcing no SMC?"
+- "Ajuda a definir ICP para minha oferta de SI da Microsoft"
+- "Preciso mapear o comitê de compra para uma conta de Shared Services"
+- "Define Anti-ICP para nossa oferta de Cloud"
+
+---
+
+### Task 1: Create `skills/microsoft-consulting-icp/SKILL.md`
+
+**Files:**
+- Create: `skills/microsoft-consulting-icp/SKILL.md`
+
+**Step 1: Create the file with correct frontmatter**
+
+```yaml
+---
+name: microsoft-consulting-icp
+description: This skill should be used when the user needs to define Ideal Customer Profiles for Microsoft platform consulting offers. Use when segmenting accounts between Enterprise and SMC, mapping buyer committees per offer type (Assessment, System Integration, Outsourcing, Shared Services), scoring opportunity fit, or defining Anti-ICP to prevent low-quality pipeline.
+license: MIT
+---
+```
+
+**Mandatory frontmatter rules:**
+- Only `name`, `description`, `license` — NO other fields
+- `name` must be kebab-case
+- Description must be a single line
+- No `version`, `author`, `platforms`, `category`, `tags`, `risk`, `created`, `updated`
+
+**Step 2: Write the skill body**
+
+The skill body must contain these required sections (in order):
+1. Purpose
+2. When to Use
+3. Workflow (with progress tracking display)
+4. Critical Rules (NEVER/ALWAYS)
+5. Example Usage (3–5 realistic scenarios)
+
+**Content specification for each section:**
+
+**Purpose:**
+> Defines Ideal Customer Profiles for Microsoft platform consulting engagements. Segments target accounts between Enterprise and SMC using Microsoft's market framework, maps buyer personas per offer type, scores fit using an adapted PURE model, and produces Anti-ICP definitions to protect pipeline quality and win-rate.
+
+**When to Use:**
+- Designing or refreshing GTM for a specific consulting offer
+- Qualifying whether an account is viable for a given offer type
+- Mapping the buying committee before engaging an account
+- Reviewing pipeline quality against ICP criteria
+- Training pre-sales teams on qualification standards
+
+**Workflow — 4 phases:**
+
+Phase 1: Account Segment Identification (Enterprise vs SMC)
+- Define Microsoft's segmentation criteria: Enterprise = top named accounts (typically 1000+ employees, strategic relationship, Microsoft-named); SMC = mid-market, volume-driven, digital-first
+- Collect firmographic signals: revenue, employee count, IT budget, Microsoft maturity (M365/Azure adoption level), existing Avanade relationship
+- Assign segment: Enterprise or SMC
+- Note: the buying motion, cycle length, and governance requirements differ significantly between segments
+
+Phase 2: Offer-Fit Scoring
+- For each of the four offer types, define fit criteria:
+  - **Assessment:** CIO/CTO sponsor exists, budget for discovery ($15K–$80K range), technology debt visible, Azure or M365 already in use, digital transformation pressure active
+  - **System Integration:** Confirmed budget ($150K+), project scope defined or definable, Microsoft platform selected or in evaluation, decision expected within quarter, IT governance in place
+  - **Outsourcing:** CFO involved, operational cost pressure explicit, FTE headcount at risk, multi-year commitment appetite, SLA expectations defined
+  - **Shared Services:** CSC or GBS structure exists or planned, process standardization mandate active, scale across geographies, CFO/COO sponsorship
+- Score each signal 0–3 using PURE model adapted: **P**ain (how acute), **U**rgency (forcing function), **R**eady (organizational readiness), **E**conomics (budget and ROI visibility)
+- Tier output: Tier 1 (pursue actively), Tier 2 (qualify further), Tier 3 (nurture), Discard
+
+Phase 3: Buyer Committee Mapping
+- Map the buying committee per offer type:
+  - Assessment: CIO/CTO (sponsor), IT Director (champion), CFO (approver for larger assessments)
+  - SI: CIO (technical sponsor), Project Sponsor (business unit), CFO/Procurement (commercial), IT Architecture (influencer)
+  - Outsourcing: CFO (primary), COO (operational), CIO (technical), HR (risk), Legal/Compliance (governance)
+  - Shared Services: CFO/COO (sponsor), Process Owner (champion), IT (enabler), HR (risk)
+- For each stakeholder: title, primary concern, success metric, likely objection, messaging angle
+- Identify: Champion (internal advocate), Decision-maker (formal authority), Blocker (risk vector)
+
+Phase 4: Anti-ICP Definition
+- Define explicitly who NOT to pursue per offer type and segment
+- Anti-ICP signals: no Microsoft investment, procurement-only contact (no executive sponsor), budget not allocated or approval cycle >18 months, no internal champion, RFP-only without prior relationship, single-vendor mandate to a competitor, contract in place with competing SI
+
+**Progress tracking display:**
+```
+[████░░░░░░░░░░░░░░░░] 25% — Phase 1/4: Account Segment Identification
+[████████░░░░░░░░░░░░] 50% — Phase 2/4: Offer-Fit Scoring
+[████████████░░░░░░░░] 75% — Phase 3/4: Buyer Committee Mapping
+[████████████████████] 100% — Phase 4/4: Anti-ICP Definition
+```
+
+**Critical Rules:**
+- NEVER score an account without identifying a named executive sponsor — no sponsor = Discard regardless of firmographics
+- NEVER conflate Enterprise and SMC motions — buying governance, cycle length, and commercial structure are fundamentally different
+- ALWAYS define Anti-ICP before presenting ICP to a pre-sales team — without it, the ICP will be gamed
+- ALWAYS map the buyer committee before proposing — knowing only the IT contact is insufficient for any offer beyond a small Assessment
+- NEVER use generic ICP criteria — every output must reference Microsoft platform maturity and the specific offer type being evaluated
+
+**Example Usage (5 scenarios):**
+1. "Define ICP para Assessment no segmento Enterprise no setor FSI"
+2. "Score esta conta para uma oportunidade de Outsourcing: [empresa, contexto]"
+3. "Mapeia o comitê de compra para um projeto de SI de $500K no Bradesco"
+4. "Quero revisar meu pipeline SMC — ajuda a aplicar Anti-ICP para eliminar oportunidades fracas"
+5. "Qual é o perfil de conta ideal para Shared Services no segmento HPS?"
+
+**Step 3: Validate word count**
+
+Target: 1500–2000 words (max 5000). Count after writing.
+
+**Step 4: Validate frontmatter**
+
+Run:
+```bash
+./scripts/validate-skill-yaml.sh skills/microsoft-consulting-icp
+```
+Expected: no errors
+
+**Step 5: Validate content quality**
+
+Run:
+```bash
+./scripts/validate-skill-content.sh skills/microsoft-consulting-icp
+```
+Expected: no errors, word count within range
+
+---
+
+### Task 2: Create `skills/microsoft-consulting-icp/README.md`
+
+**Files:**
+- Create: `skills/microsoft-consulting-icp/README.md`
+
+**Step 1: Write README with required Metadata table**
+
+```markdown
+# Microsoft Consulting ICP
+
+Define Ideal Customer Profiles for Microsoft platform consulting offers by account segment and offer type.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Version | 1.0.0 |
+| Author | Eric Andrade |
+| Created | 2026-04-03 |
+| Updated | 2026-04-03 |
+| Platforms | Claude Code, GitHub Copilot, OpenAI Codex, Gemini CLI, Cursor IDE |
+| Category | GTM & Sales |
+| Tags | gtm, icp, microsoft, consulting, avanade, enterprise, smc, presales |
+| Risk | Low |
+
+## Overview
+
+[2–3 paragraph description of what the skill does, who it's for, and what it produces]
+
+## When to Use
+
+[Bulleted list matching SKILL.md When to Use section]
+
+## Example Outputs
+
+[2–3 example outputs the skill produces]
+```
+
+**Note:** Dates, version, author go HERE — not in `SKILL.md` frontmatter.
+
+---
+
+## Skill 2: `consulting-gtm-designer`
+
+### Overview
+
+**Purpose:** Build a GTM strategy for Microsoft platform consulting offers (Assessment, SI, Outsourcing, Shared Services) targeting Enterprise or SMC accounts. Produces a GTM canvas per offer type including value proposition by pillar, entry motion, qualification gates, expansion playbook, and win metrics.
+
+**Why not `product-strategy`?** `product-strategy` is designed for product companies (PLG vs SLG, pricing tiers, freemium). `consulting-gtm-designer` is designed for professional services: offer packaging, consulting-specific entry motions, pre-sales investment governance, delivery credibility requirements, and the Assessment → SI → Outsourcing → Shared Services progression as a strategic expansion arc.
+
+**Trigger phrases:**
+- "Monta o GTM para nossa oferta de AI Assessment no Enterprise"
+- "Como entrar em contas SMC com oferta de Cloud & AI Platforms?"
+- "Preciso estruturar o GTM para Outsourcing no segmento FSI"
+- "Qual é a estratégia de expansão de um Assessment para um projeto de SI?"
+- "Ajuda a definir value prop por pilar para o segmento HPS"
+
+---
+
+### Task 3: Create `skills/consulting-gtm-designer/SKILL.md`
+
+**Files:**
+- Create: `skills/consulting-gtm-designer/SKILL.md`
+
+**Step 1: Create the file with correct frontmatter**
+
+```yaml
+---
+name: consulting-gtm-designer
+description: This skill should be used when the user needs to build a Go-To-Market strategy for professional services consulting offers on the Microsoft platform. Use when designing entry motion by account segment, structuring value propositions per GTM pillar, planning the Assessment-to-SI-to-Outsourcing expansion arc, or defining win metrics for consulting pipeline.
+license: MIT
+---
+```
+
+**Step 2: Write the skill body**
+
+**Purpose:**
+> Builds GTM strategy for Microsoft platform consulting offers. Covers offer positioning by segment (Enterprise vs SMC), value proposition by GTM pillar (AI Business Solutions, Security, Cloud & AI Platforms, Advisory), entry and expansion motions, pre-sales investment gates, and win metrics. Produces a GTM canvas per offer type that a sales team can execute without ambiguity.
+
+**When to Use:**
+- Designing or refreshing GTM for a specific consulting offer type
+- Defining value proposition differentiation across Microsoft pillars
+- Planning the entry motion for a new account or segment
+- Structuring the expansion arc from Assessment to larger engagements
+- Reviewing pipeline strategy alignment with market conditions
+
+**Workflow — 4 phases:**
+
+Phase 1: Offer × Segment Definition
+- Identify the offer type: Assessment, System Integration, Outsourcing, or Shared Services
+- Identify the target segment: Enterprise or SMC
+- Define offer scope: what is included, what is explicitly out of scope, typical duration and team composition
+- Define the offer's role in the portfolio: entry offer (Assessment) or expansion offer (SI, Outsourcing, Shared Services)
+- Note pricing range and commercial structure (T&M, Fixed Fee, or Hybrid) appropriate to each combination
+
+Phase 2: Value Proposition by Pillar
+- For each Microsoft GTM pillar, build the value prop specific to the offer type and segment:
+  - **AI Business Solutions:** ROI from AI agent adoption, productivity gains, process automation metrics, Copilot deployment outcomes
+  - **Security:** Risk reduction quantification, compliance coverage (LGPD, BACEN, HIMSS for healthcare), Zero Trust implementation outcomes, incident cost avoidance
+  - **Cloud & AI Platforms:** Azure migration ROI, cloud unit economics vs. on-premise, modernization speed, platform lock-in risk mitigation
+  - **Advisory:** Strategic clarity from Assessment output, roadmap quality, executive alignment, decision acceleration
+- Translate each value prop into buyer-specific language per the buying committee identified in `microsoft-consulting-icp`
+- Identify proof points: case studies, client references, Microsoft co-sell positioning
+
+Phase 3: Entry and Expansion Motion
+- **Entry motion per segment:**
+  - Enterprise: executive-led, long-cycle, relationship-first, Assessment as risk-reduction vehicle before larger commitment; co-sell with Microsoft account team
+  - SMC: digital-first, offer-packaged, faster cycle, standardized Assessment → digital SI tracks; leverage Microsoft partner network
+- **Expansion arc:** Assessment → SI → Outsourcing/Shared Services
+  - Assessment exit criteria: what must be true for the client to commit to SI
+  - SI exit criteria: what must be true for the client to consider Outsourcing or Shared Services
+  - Expansion timing triggers: delivery milestone, renewal event, executive change, regulatory pressure
+- **Pre-sales investment governance:**
+  - When to invest pre-sales hours (qualification threshold)
+  - When to stop and disqualify
+  - Governance approval gates (e.g., OpTeam/SEOps equivalent)
+
+Phase 4: Win Metrics and GTM Canvas
+- Define win metrics per offer type:
+  - Assessment: conversion rate from Assessment to SI (target: >40%), time-to-proposal, client satisfaction score
+  - SI: win rate in competitive evaluations, delivery margin, reference-ability post-delivery
+  - Outsourcing: contract duration, FTE displacement ratio, SLA achievement, renewal rate
+  - Shared Services: cross-geography expansion, process standardization rate, cost per process
+- Produce 1-page GTM Canvas per offer × segment combination:
+  - Offer definition
+  - Target ICP
+  - Value prop (by pillar)
+  - Entry motion
+  - Expansion arc
+  - Pre-sales gates
+  - Win metrics
+  - Anti-ICP (who NOT to pursue)
+
+**Progress tracking display:**
+```
+[████░░░░░░░░░░░░░░░░] 25% — Phase 1/4: Offer × Segment Definition
+[████████░░░░░░░░░░░░] 50% — Phase 2/4: Value Proposition by Pillar
+[████████████░░░░░░░░] 75% — Phase 3/4: Entry and Expansion Motion
+[████████████████████] 100% — Phase 4/4: Win Metrics and GTM Canvas
+```
+
+**Critical Rules:**
+- NEVER design a GTM without specifying the offer type AND the target segment — the motion is fundamentally different
+- NEVER produce a value prop without translating it into buyer-specific language (CFO hears different value than CIO)
+- ALWAYS include the expansion arc — an Assessment without an expansion path is a one-time transaction, not a GTM motion
+- ALWAYS define pre-sales investment gates — without governance, pre-sales hours will be spent on Tier 3 and Tier 4 accounts
+- NEVER conflate Microsoft pillar positioning with generic technology positioning — the Avanade/Microsoft co-sell relationship is a differentiation asset and must appear explicitly
+
+**Example Usage (5 scenarios):**
+1. "Monta o GTM para AI Business Solutions Assessment no segmento Enterprise — setor FSI"
+2. "Como estruturo a expansão de um Assessment de Cloud para um projeto de SI de $500K?"
+3. "Define a value prop de Security para o segmento SMC no setor PRD"
+4. "Quero revisar o GTM de Outsourcing para o segmento CMT — identifica o que está fraco"
+5. "Cria o GTM Canvas para Shared Services no segmento HPS com foco em Advisory"
+
+**Step 3: Validate word count and scripts**
+
+Run:
+```bash
+./scripts/validate-skill-yaml.sh skills/consulting-gtm-designer
+./scripts/validate-skill-content.sh skills/consulting-gtm-designer
+```
+Expected: no errors
+
+---
+
+### Task 4: Create `skills/consulting-gtm-designer/README.md`
+
+**Files:**
+- Create: `skills/consulting-gtm-designer/README.md`
+
+**Step 1: Write README with Metadata table**
+
+Same structure as Task 2, adapted for `consulting-gtm-designer`.
+
+---
+
+## Task 5: Regenerate Indexes
+
+After both skills are created and validated:
+
+**Step 1: Regenerate skills index**
+
+```bash
+python3 scripts/generate-skills-index.py
+```
+Expected: `skills_index.json` updated with 2 new entries
+
+**Step 2: Regenerate catalog**
+
+```bash
+python3 scripts/generate-catalog.py
+```
+Expected: `CATALOG.md` updated with 2 new skills
+
+**Step 3: Verify git status**
+
+```bash
+git status --short
+```
+Expected: only intentional changes — new skill dirs + updated index/catalog
+
+---
+
+## Task 6: Update Documentation (Pre-Release)
+
+Do NOT update version or do a release in this task batch. These doc updates are required before the next release:
+
+**Files to update when ready to release:**
+- `README.md` — add both skills to the GTM/Sales category table; bump badge count from 46 to 48
+- `CLAUDE.md` — add both skills to architecture tree and Skill Types section
+- `CHANGELOG.md` — add entry for new skills
+- `cli-installer/README.md` — update skill count if mentioned
+- `.claude-plugin/marketplace.json` — update description if skill count is mentioned
+- `bundles.json` — evaluate whether either skill belongs in `product` or `essential` bundle
+
+**Version bump (deferred to release):**
+```bash
+node scripts/release.js minor
+```
+This will: sync all 5 version files, bump from 1.21.8 → 1.22.0.
+
+---
+
+## Deferred: Skill 3 Candidate — `presales-qualifier`
+
+**Scope:** Pre-sales qualification framework for Microsoft consulting deals. Structured go/no-go criteria, PURE scoring adapted to consulting context, cycle time governance, win-rate tracking by offer type and segment, and kill conditions for low-probability pipeline.
+
+**Why deferred:** Implement after Skills 1 and 2 are reviewed. This skill has higher risk of overlap with `abx-strategy` Framework 3 (PURE scoring) and needs explicit differentiation in the consulting/services context before implementation.
+
+**Trigger phrases:**
+- "Qualifica esta oportunidade de Outsourcing para o Bradesco"
+- "Qual é o go/no-go para investir pre-sales nesta conta?"
+- "Nosso win-rate está baixo — ajuda a revisar os critérios de qualificação"
+
+---
+
+## Validation Criteria
+
+Before marking implementation complete:
+
+- [ ] Both `SKILL.md` files have only `name`, `description`, `license` in frontmatter
+- [ ] No `created`, `updated`, `version`, or `author` fields in any `SKILL.md`
+- [ ] Both `README.md` files have complete Metadata tables with dates and version
+- [ ] Both skills pass `validate-skill-yaml.sh` and `validate-skill-content.sh`
+- [ ] Word count: 1500–2000 words each (verified)
+- [ ] `skills_index.json` and `CATALOG.md` regenerated
+- [ ] No changes to `bundles.json`, `README.md`, `CHANGELOG.md`, or version files (those are release-time)
+- [ ] Skills look native to the repository — no foreign structure or verbatim imported content
+
+---
+
+## Success Criteria
+
+This plan succeeds when:
+- Both skills are in `skills/` with valid structure and content
+- Indexes are regenerated and up to date
+- The skills are discoverable via realistic trigger phrases in the Microsoft consulting context
+- The implementation can proceed without architectural ambiguity
+- Eric can invoke either skill and receive a structured output relevant to his VP/GTM context at Avanade

--- a/docs/plan/2026-04-03-obsidian-skills-adoption-plan.md
+++ b/docs/plan/2026-04-03-obsidian-skills-adoption-plan.md
@@ -1,0 +1,311 @@
+# Obsidian Skills Adoption Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use `writing-plans` discipline to keep this work low-ambiguity. Do not implement any Obsidian skill until the external repository triage and user approval gates in this plan are complete.
+
+**Goal:** Evaluate external Obsidian-related repositories, select the highest-value workflows, and convert the approved set into repository-native skills under `claude-superskills`.
+
+**Architecture:** External repositories are reference inputs, not source code to import directly. All approved capabilities must be normalized into this repository's skill architecture under `skills/`, with local naming, local metadata, local evals, and local documentation. The process must deliberately filter out generic PKM ideas, low-value overlap, and vendor-specific assumptions before any files are created.
+
+**Tech Stack:** Markdown skills (`SKILL.md`, `README.md`), repository metadata (`bundles.json`, `skills_index.json`, `CATALOG.md`), optional `templates/`, `references/`, `scripts/`, git branch `feature/obsidian-skills-plan`.
+
+---
+
+## Preconditions
+
+Before executing any implementation work, all of the following must be true:
+
+- the user has provided one or more GitHub repositories to analyze
+- each repository has been triaged against current repository scope
+- the first Obsidian skill set has been approved explicitly by the user
+- a follow-up implementation plan exists for the exact approved skills
+
+## Repository Rules
+
+- `skills/` remains the only source of truth for skill content
+- do not copy raw foreign folder structures into this repository
+- do not import external prompts or docs verbatim without review and adaptation
+- start with a small initial Obsidian cluster: target 2 to 4 skills
+- if a candidate idea overlaps with an existing skill, prefer extending or differentiating clearly instead of duplicating
+- use `docs/plan/` for durable planning artifacts in this branch; do not use the ignored `docs/plans/`
+
+## Decision Gates
+
+The work stops for user confirmation at these gates:
+
+1. After the external repository inventory is summarized
+2. After the candidate Obsidian skill matrix is proposed
+3. After the first 2 to 4 skills are selected
+4. Before any implementation files are created under `skills/`
+
+## Expected Outputs
+
+At the end of the planning phase, the branch should contain:
+
+- this plan file
+- a repository triage summary for the external Obsidian references
+- a candidate skill matrix with keep/merge/discard decisions
+- an approved implementation target list for the first Obsidian skills
+
+The branch should not yet contain:
+
+- new `skills/obsidian-*` directories
+- bundle changes
+- regenerated indexes
+- release/version changes
+
+## Task 1: Intake External Repositories
+
+**Files:**
+- Update: `docs/plan/2026-04-03-obsidian-skills-adoption-plan.md`
+- Create later if needed: `docs/plan/obsidian-repo-triage.md`
+
+**Step 1: Collect repository inputs**
+
+Input required from user:
+- GitHub repository URLs
+- what looked valuable in each repository
+- desired Obsidian focus:
+  - vault organization
+  - note linking
+  - writing
+  - research
+  - review workflows
+  - automation
+
+Expected: a bounded list of repositories to inspect
+
+**Step 2: Inventory each repository**
+
+For each repository, record:
+- repository name and URL
+- project purpose
+- Obsidian-relevant skills, prompts, agents, scripts, templates, commands
+- plugin or tooling dependencies
+- signs of personal-only workflow assumptions
+
+Expected: a repo-by-repo inventory with concrete extracted capabilities
+
+**Step 3: Classify extracted assets**
+
+For each extracted item, assign one:
+- Obsidian-specific workflow
+- generic PKM workflow
+- generic writing/research workflow
+- setup/config reference only
+- discard
+
+Expected: clear separation between true Obsidian opportunities and noise
+
+**Validation**
+
+Run this reasoning check manually:
+- every candidate left in scope must answer: "Why is this better as an Obsidian skill than as a generic productivity skill?"
+
+## Task 2: Compare Against Current Repository Coverage
+
+**Files:**
+- Review: `skills/`
+- Update later if needed: `docs/plan/obsidian-repo-triage.md`
+
+**Step 1: Map candidates to existing skills**
+
+Compare repository findings against the existing capabilities in `skills/`, especially adjacent areas such as:
+- `writing-plans`
+- `deep-research`
+- `docling-converter`
+- `productivity`-style and writing-oriented skills
+
+Expected: a list of overlaps and differences
+
+**Step 2: Identify duplication risk**
+
+For each candidate, decide:
+- new skill
+- extension of an existing concept
+- template/reference only
+- discard
+
+Expected: no candidate remains ambiguously classified
+
+**Step 3: Score each candidate**
+
+Use these criteria:
+- Obsidian specificity
+- reusability across many vaults
+- low dependency burden
+- likely trigger quality
+- distinct value versus current repository
+- ability to teach a repeatable workflow
+
+Expected: shortlist candidates with explicit rationale
+
+**Validation**
+
+The shortlist should be small. If more than 4 strong candidates remain for the first batch, rank them and defer the rest.
+
+## Task 3: Define The Initial Obsidian Skill Set
+
+**Files:**
+- Update: `docs/plan/2026-04-03-obsidian-skills-adoption-plan.md`
+- Create later if needed: `docs/plan/obsidian-skill-matrix.md`
+
+**Step 1: Propose final candidate names**
+
+Draft names should be outcome-oriented, for example:
+- `obsidian-vault-architect`
+- `obsidian-note-linking`
+- `obsidian-writing-workflow`
+- `obsidian-research-notes`
+- `obsidian-review-rhythm`
+
+Expected: names that fit this repository's style and are not plugin-branded unless unavoidable
+
+**Step 2: Define boundaries for each proposed skill**
+
+For each selected skill, specify:
+- one-sentence purpose
+- ideal user requests
+- what is explicitly out of scope
+- optional dependencies
+- whether helper assets are required
+
+Expected: each skill has a crisp boundary and does not overlap excessively with another approved skill
+
+**Step 3: Ask for user approval**
+
+Present:
+- selected 2 to 4 skills
+- discarded candidates
+- risks and assumptions
+
+Expected: explicit user confirmation before implementation planning begins
+
+## Task 4: Convert Approved Skills Into Exact File-Level Work
+
+**Files:**
+- Create for each approved skill:
+  - `skills/<approved-skill>/SKILL.md`
+  - `skills/<approved-skill>/README.md`
+  - `skills/<approved-skill>/evals/evals.json`
+  - `skills/<approved-skill>/evals/trigger-eval.json`
+- Optional per skill:
+  - `skills/<approved-skill>/templates/...`
+  - `skills/<approved-skill>/references/...`
+  - `skills/<approved-skill>/scripts/...`
+- Modify later:
+  - `bundles.json`
+  - `README.md`
+  - `skills_index.json`
+  - `CATALOG.md`
+
+**Step 1: Define the minimum asset set per skill**
+
+Default rule:
+- every approved skill gets `SKILL.md`, `README.md`, and starter evals
+- `templates/`, `references/`, and `scripts/` are added only when justified
+
+Expected: no gold-plating, no empty directories without purpose
+
+**Step 2: Write an implementation checklist per skill**
+
+For each approved skill, define:
+- category placement
+- README metadata needs
+- likely triggers
+- workflow skeleton
+- eval coverage expectations
+- whether it belongs in any bundle
+
+Expected: implementation can proceed without discovering structure mid-flight
+
+**Step 3: Define regeneration and doc updates**
+
+After skill implementation, the expected sequence will be:
+
+```bash
+python3 scripts/generate-skills-index.py
+python3 scripts/generate-catalog.py
+git status --short
+```
+
+Expected:
+- `skills_index.json` updated
+- `CATALOG.md` updated
+- only intentional metadata/docs changes remain
+
+## Task 5: Validation Criteria For The Future Implementation
+
+**Files:**
+- Review: each new `skills/<approved-skill>/...` directory
+
+**Step 1: Validate repository consistency**
+
+Check:
+- naming matches repository conventions
+- no duplicated skill semantics
+- no obsolete or imported foreign structure
+- optional assets exist only when justified
+
+Expected: each skill looks native to this repository
+
+**Step 2: Validate trigger quality**
+
+Check:
+- trigger phrases are realistic
+- Obsidian framing is explicit where needed
+- the skill is discoverable from likely user requests
+
+Expected: trigger evals reflect real Obsidian use cases
+
+**Step 3: Validate public scope impact**
+
+Check whether public-facing docs need updates:
+- `README.md`
+- `cli-installer/README.md`
+- `.claude-plugin/marketplace.json`
+
+Expected: only update public docs if the repository's visible capability scope materially changes
+
+## Candidate Triage Template
+
+Use this template for each repository once the user sends it:
+
+```markdown
+### Repository: <name>
+
+- URL: <url>
+- Purpose:
+- Obsidian-relevant assets:
+- Dependencies:
+- Strong ideas worth adapting:
+- Weak or discardable ideas:
+- Overlap with existing skills:
+- Recommendation:
+```
+
+## Candidate Skill Template
+
+Use this template for each shortlisted skill:
+
+```markdown
+### Proposed Skill: <name>
+
+- Purpose:
+- Source inspiration:
+- Why it is Obsidian-specific:
+- Why it is not redundant:
+- Likely triggers:
+- Required files:
+- Optional files:
+- Risks:
+- Recommendation:
+```
+
+## Success Criteria
+
+This plan succeeds when:
+
+- every external repository has been triaged with explicit keep/merge/discard logic
+- the first Obsidian skill batch is constrained to a justified 2 to 4 skills
+- each approved skill has a clear implementation shape before any files are created
+- the resulting work can be executed without architectural ambiguity or repository drift

--- a/scripts/validate-skill-yaml.sh
+++ b/scripts/validate-skill-yaml.sh
@@ -12,8 +12,8 @@ fi
 
 echo "🔍 Validating YAML frontmatter in $SKILL_PATH/SKILL.md..."
 
-# Extract frontmatter
-FRONTMATTER=$(sed -n '/^---$/,/^---$/p' "$SKILL_PATH/SKILL.md" | sed '1d;$d')
+# Extract frontmatter — stop after the FIRST --- block so code examples don't pollute the check
+FRONTMATTER=$(awk 'BEGIN{count=0} /^---$/{count++; next} count==1{print} count==2{exit}' "$SKILL_PATH/SKILL.md")
 
 # Check required fields
 for field in name description license; do

--- a/skills/excalidraw-diagram/README.md
+++ b/skills/excalidraw-diagram/README.md
@@ -1,0 +1,80 @@
+# ✏️ excalidraw-diagram
+
+> Create hand-drawn style diagrams using Excalidraw — architecture sketches, concept maps, user flows, C4 diagrams, and org charts. Outputs valid Excalidraw JSON ready for Obsidian or excalidraw.com.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Content / Visualization                            |
+| Tags      | excalidraw, diagram, whiteboard, architecture, sketch, obsidian |
+| Risk      | Low                                                |
+
+## Overview
+
+`excalidraw-diagram` generates diagrams in the Excalidraw JSON format — a hand-drawn, whiteboard aesthetic format used for architecture sketches, concept maps, and informal system diagrams. The output can be embedded in Obsidian (via the Excalidraw plugin), opened at excalidraw.com, or rendered in VS Code.
+
+## Features
+
+- **Hand-drawn aesthetic** — Uses Excalidraw's `roughness: 1` for the informal sketch look
+- **Multiple diagram types** — Architecture, concept map, user flow, C4 context, sequence, org chart
+- **Obsidian-ready output** — Generates `.excalidraw.md` files embeddable with `![[filename]]`
+- **Color coding** — Consistent color scheme (blue=frontend, green=backend, orange=external, purple=data)
+- **Standalone JSON** — Valid Excalidraw format pasteable directly into excalidraw.com
+- **Design principles** — Limits to 15 elements per diagram, labels on all arrows, minimum spacing
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Create an Excalidraw diagram for..."
+- "Draw a sketch of the system architecture"
+- "Whiteboard-style diagram of..."
+- "Hand-drawn concept map for..."
+- "Excalidraw C4 context diagram"
+- "Sketch the user registration flow"
+- "Draw this informally for a workshop"
+
+## Requirements
+
+To render the diagram:
+
+- **Obsidian**: Install [Excalidraw plugin](https://github.com/zsviczian/obsidian-excalidraw-plugin) by Zsolt Viczian
+- **Browser**: [excalidraw.com](https://excalidraw.com) — paste JSON
+- **VS Code**: Install "Excalidraw" VS Code extension
+
+## Diagram Types
+
+| Type | Best For |
+|------|---------|
+| Systems architecture | Services, components, APIs, databases |
+| Concept map | Ideas radiating from a central concept |
+| User flow | Step-by-step processes with decision points |
+| C4 context | Person → System → External systems |
+| Sequence sketch | Actors with messages flowing over time |
+| Org chart | Hierarchy tree for teams or systems |
+
+## Color Convention
+
+| Color | Meaning |
+|-------|---------|
+| Blue (`#d0ebff`) | Frontend / user-facing |
+| Green (`#d3f9d8`) | Backend / processing |
+| Orange (`#ffe8cc`) | External systems |
+| Purple (`#f3d9fa`) | Databases / storage |
+| Gray (`#f1f3f5`) | Infrastructure / platform |
+
+## Examples
+
+| Request | Output |
+|---------|--------|
+| "Three-tier web architecture" | Browser → API → Database with labeled arrows |
+| "Concept map for product strategy" | Radial layout with 6 concept branches |
+| "User registration flow" | Left-to-right process with decision diamond |
+| "C4 context for our SaaS app" | User, Web App, Payment Provider, Email Service |
+| "Org chart for the product team" | Top-down tree with CPO, PM Lead, Design Lead |

--- a/skills/excalidraw-diagram/SKILL.md
+++ b/skills/excalidraw-diagram/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: excalidraw-diagram
+description: This skill should be used when the user needs to create a diagram using Excalidraw — a hand-drawn style whiteboard tool. Use when the user wants a sketch-style architecture diagram, system design, concept map, user flow, or any visual that benefits from the informal, freehand aesthetic of Excalidraw. Outputs an embedded Excalidraw file ready for use in Obsidian or standalone.
+license: MIT
+---
+
+## Purpose
+
+This skill creates diagrams using the Excalidraw format — a JSON-based drawing format rendered by the Excalidraw library and its integrations. The output has a distinctive hand-drawn, whiteboard aesthetic that is ideal for architecture sketches, concept maps, brainstorming visuals, and informal system diagrams.
+
+Unlike Mermaid which produces precise, flow-based diagrams from DSL text, Excalidraw uses geometric primitives (rectangles, ellipses, arrows, text, lines) laid out on a freeform canvas. The hand-drawn style makes it suitable for early-stage thinking, workshop facilitation, and documentation where the informal look communicates "this is a sketch, not a specification."
+
+In Obsidian, Excalidraw files are supported via the **Excalidraw plugin** by Zsolt Viczian, which renders `.excalidraw` files natively and allows embedding them in notes.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user explicitly asks for an Excalidraw diagram
+- The user wants a "sketch-style" or "whiteboard" diagram
+- The user says "draw this informally" or "make it look hand-drawn"
+- The user needs a system architecture or C4-style diagram with an informal aesthetic
+- The user wants a concept map or mind map with free positioning (not the rigid Mermaid mindmap syntax)
+- The user is working in Obsidian and wants to embed a whiteboard-style drawing
+- The user wants a diagram exported as `.excalidraw` file or embedded in a Markdown note
+
+Do NOT use this skill when:
+
+- The user wants precise, structured flowcharts with clear graph routing — use `mermaid-diagram` instead
+- The user wants a structured knowledge graph layout in Obsidian — use `obsidian-canvas` instead
+- The user asks for a "professional" or "polished" diagram (Excalidraw's hand-drawn look is intentionally informal)
+- The user wants to embed code blocks or data-driven diagrams
+
+## Excalidraw Output Formats
+
+| Format | Use Case |
+|--------|---------|
+| Obsidian embed (`.md` with JSON) | Embedded in an Obsidian note, edited with the Excalidraw plugin |
+| Standalone `.excalidraw` file | Opened directly in Excalidraw app or excalidraw.com |
+| Animated SVG | Excalidraw plugin "export animated" feature — for presentations |
+
+## Diagram Types
+
+### Systems architecture
+
+Boxes representing services/components connected with labeled arrows. Uses color to group related components (e.g., blue for frontend, green for backend, orange for external).
+
+### Concept map / mind map
+
+Central concept with radiating branches. Each branch is a related idea. Uses curved arrows and freeform text nodes.
+
+### User flow / journey
+
+Horizontal swim lanes for actors. Steps flow left to right. Decision points use diamond shapes.
+
+### C4-style sketch
+
+Four levels: System Context → Container → Component → Code. Each level drawn as nested boxes with arrows for interactions.
+
+### Sequence sketch
+
+Actors as columns, time flowing downward. Message arrows between columns with labels.
+
+## Workflow
+
+### Step 1: Identify the Diagram Type and Content
+
+From the user's request, determine:
+
+1. **Diagram type** from the list above
+2. **Main components** — the nodes/entities in the diagram
+3. **Relationships** — how components connect (and the labels on connections)
+4. **Layout preference** — horizontal flow, vertical hierarchy, radial, or freeform
+
+If the user's request is vague ("draw our system"), ask one clarifying question:
+- "What are the main components to include?"
+- "Should this be a sketch of the overall architecture, or a sequence of interactions?"
+
+### Step 2: Design the Layout
+
+Plan the component positions before writing the Excalidraw JSON:
+
+- **Architecture diagrams**: Group related components into clusters. Place external systems at the edges. Group by layer (frontend → backend → data → external).
+- **Concept maps**: Place the central concept in the middle. Branch outward with related concepts at a radius of 200-300 units.
+- **User flows**: Use horizontal layout. Actors as column headers at the top. Steps flow left to right.
+- **C4 sketches**: Use nested rectangles. Outer box = system, inner boxes = containers, innermost = components.
+
+Color guidelines:
+- Blue (`#1971c2` / fill `#d0ebff`) — user-facing or frontend components
+- Green (`#2f9e44` / fill `#d3f9d8`) — backend or processing components
+- Orange (`#e8590c` / fill `#ffe8cc`) — external systems or third-party services
+- Purple (`#862e9c` / fill `#f3d9fa`) — data storage or databases
+- Gray (`#495057` / fill `#f1f3f5`) — infrastructure or platform components
+
+### Step 3: Generate the Excalidraw JSON
+
+Excalidraw diagrams are JSON objects with an `elements` array. Each element is a shape with position, size, style, and content properties.
+
+**Element schema:**
+```json
+{
+  "type": "rectangle",
+  "id": "unique-id",
+  "x": 100,
+  "y": 200,
+  "width": 160,
+  "height": 80,
+  "strokeColor": "#1971c2",
+  "backgroundColor": "#d0ebff",
+  "fillStyle": "hachure",
+  "strokeWidth": 2,
+  "roughness": 1,
+  "opacity": 100,
+  "text": "Component Name",
+  "fontSize": 16,
+  "fontFamily": 1,
+  "textAlign": "center",
+  "verticalAlign": "middle"
+}
+```
+
+**Shape types:**
+- `rectangle` — boxes for components and systems
+- `ellipse` — circles/ovals for actors or rounded shapes
+- `diamond` — decision points
+- `arrow` — directed connections between components
+- `line` — undirected connections
+- `text` — standalone labels
+
+**Arrow element:**
+```json
+{
+  "type": "arrow",
+  "id": "arrow-1",
+  "x": 260,
+  "y": 240,
+  "width": 140,
+  "height": 0,
+  "points": [[0, 0], [140, 0]],
+  "startBinding": {"elementId": "source-id", "gap": 5, "focus": 0},
+  "endBinding": {"elementId": "target-id", "gap": 5, "focus": 0},
+  "strokeColor": "#343a40",
+  "strokeWidth": 2,
+  "roughness": 1
+}
+```
+
+**Full Excalidraw file structure:**
+```json
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "https://excalidraw.com",
+  "elements": [...],
+  "appState": {
+    "gridSize": null,
+    "viewBackgroundColor": "#ffffff"
+  }
+}
+```
+
+### Step 4: Output the Diagram
+
+**For standalone `.excalidraw` file output:**
+Output the complete JSON block in a fenced code block labeled `json`. Instruct the user to save it as `DiagramName.excalidraw`.
+
+**For Obsidian embed:**
+Wrap the JSON in an Obsidian Excalidraw note format — a Markdown file with an `excalidraw-plugin: parsed` frontmatter and the JSON embedded in a code fence:
+
+````markdown
+---
+excalidraw-plugin: parsed
+tags:
+  - excalidraw
+---
+
+```json
+{
+  "type": "excalidraw",
+  ...
+}
+```
+````
+
+Save as `DiagramName.excalidraw.md` in the vault. Embed in any note with `![[DiagramName.excalidraw.md]]`.
+
+**For animated SVG:**
+Note that animated export requires the Obsidian Excalidraw plugin's export command — it cannot be generated as pure JSON. Guide the user through: Design view → ⋮ menu → Export as animated SVG.
+
+### Step 5: Provide Rendering Instructions
+
+After the output, explain how to use it:
+
+- **Obsidian**: Install the Excalidraw plugin by Zsolt Viczian. Save the file with `.excalidraw.md` extension. Open in Obsidian to see the rendered diagram. Embed with `![[filename.excalidraw.md]]`.
+- **Excalidraw.com**: Go to [excalidraw.com](https://excalidraw.com) → ☰ Open → paste JSON.
+- **VS Code**: Install the "Excalidraw" VS Code extension to render `.excalidraw` files.
+
+## Design Principles
+
+**Clarity over complexity:**
+- Limit to 10-15 elements per diagram. Larger diagrams should be split.
+- Every arrow must have a label if the relationship is not obvious.
+- Avoid crossing arrows where possible — reroute elements to minimize crossings.
+
+**Grouping by color:**
+- Use the color scheme consistently: blue = frontend, green = backend, orange = external.
+- Add a legend box at the bottom right when using 3+ colors.
+
+**Typography:**
+- Use `fontFamily: 1` (the hand-drawn font) for titles and labels.
+- Keep label text short: 3-5 words maximum per element.
+- Use ALL_CAPS or Title Case for component names, sentence case for descriptions.
+
+**Spacing:**
+- Maintain at least 40px gap between elements to prevent crowding.
+- Grid spacing of 20px keeps elements visually aligned without rigid structure.
+- Arrow labels should be positioned midpoint between source and target.
+
+## Critical Rules
+
+**NEVER:**
+- Output partial JSON that is not valid Excalidraw format
+- Use element IDs that are duplicated — every ID must be unique
+- Reference an element in a binding that does not exist in the elements array
+- Include CJK characters, non-ASCII text, or language-specific content in labels
+- Use more than 20 elements without suggesting the diagram be split
+- Output a Mermaid block when the user asked for Excalidraw
+
+**ALWAYS:**
+- Use the `roughness: 1` property for the hand-drawn aesthetic
+- Assign unique, descriptive IDs (e.g., `frontend-ui`, `api-gateway`, `user-db`)
+- Include a label on every arrow
+- Output valid JSON that can be pasted directly into Excalidraw or saved as a file
+- Note which Obsidian plugin is required (Excalidraw by Zsolt Viczian)
+
+## Example Usage
+
+**Example 1: Three-tier web architecture**
+
+User: "Draw a simple three-tier web architecture: browser, API server, and database."
+
+Produces: An Excalidraw JSON with three boxes (Browser in blue, API Server in green, Database in purple) connected by two labeled arrows (HTTP Request/Response, SQL Query/Result). Grid layout, left to right.
+
+---
+
+**Example 2: Concept map for product strategy**
+
+User: "Create a concept map where Product Strategy is the center, connected to: Vision, ICP, Positioning, Pricing, GTM, and Roadmap."
+
+Produces: A radial layout with "Product Strategy" as a central ellipse and six boxes arranged around it, each connected with an arrow. Consistent spacing (~250px radius), short labels.
+
+---
+
+**Example 3: User registration flow**
+
+User: "Sketch a user registration flow: User fills form → Validate email → Check if email exists → (Yes) Show error → (No) Hash password → Save to DB → Send confirmation."
+
+Produces: A left-to-right flowchart with rectangles for process steps, a diamond for the decision point, two branches (Yes to error box, No continuing the flow), and end at "Send confirmation."
+
+---
+
+**Example 4: C4 Context diagram**
+
+User: "Draw a C4 context diagram for our SaaS application. Users interact with our Web App. The Web App calls our Payment Provider and sends emails via our Email Service."
+
+Produces: A C4-style sketch with User as a person icon (ellipse), Web App as the central rectangle, and two external system boxes (Payment Provider, Email Service) at the right edge. Labeled arrows for each interaction.
+
+---
+
+**Example 5: Team structure org chart**
+
+User: "Quick org chart sketch: CPO at top, under CPO are PM Lead and Design Lead, under PM Lead are three PMs, under Design Lead are two Designers."
+
+Produces: A top-down tree with seven total boxes, connected by hierarchical lines, using gray for the org structure coloring and clear label names.

--- a/skills/excalidraw-diagram/evals/evals.json
+++ b/skills/excalidraw-diagram/evals/evals.json
@@ -1,0 +1,75 @@
+{
+  "skill_name": "excalidraw-diagram",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create an Excalidraw diagram showing a simple three-tier web architecture: Browser (client), API Server (backend), and PostgreSQL Database. Use color coding and include labeled arrows.",
+      "expected_output": "Valid Excalidraw JSON with three elements (rectangle for browser in blue, rectangle for API server in green, rectangle/cylinder for DB in purple), two arrow elements with labels (e.g., HTTP Request, SQL Query), and correct binding references.",
+      "expectations": [
+        "Output is valid JSON starting with {\"type\": \"excalidraw\", \"version\": 2",
+        "Contains at least 3 shape elements and 2 arrow elements",
+        "Browser element uses blue color scheme",
+        "API Server element uses green color scheme",
+        "Database element uses purple color scheme",
+        "Arrows have labels",
+        "All element IDs are unique",
+        "Arrow bindings reference valid element IDs",
+        "roughness is set to 1 for hand-drawn look"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Draw a concept map in Excalidraw with 'Product Strategy' at the center and six branches: Vision, ICP, Positioning, Pricing, GTM, and Roadmap.",
+      "expected_output": "Valid Excalidraw JSON with a central ellipse for Product Strategy and six surrounding boxes/ellipses for each branch, connected by arrows from center to each branch. Radial layout with consistent spacing.",
+      "expectations": [
+        "Output is valid Excalidraw JSON",
+        "Contains a central element labeled Product Strategy",
+        "Contains 6 branch elements labeled Vision, ICP, Positioning, Pricing, GTM, Roadmap",
+        "6 arrows connecting center to each branch",
+        "Positions spread around the center (not all stacked)",
+        "All IDs unique, arrow bindings valid"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create an Excalidraw user flow sketch for user login: start with User enters credentials, then Validate credentials, then a decision: Valid? Yes → Redirect to dashboard, No → Show error message with option to retry.",
+      "expected_output": "Valid Excalidraw JSON with process boxes for each step, a diamond shape for the decision point, two branch arrows labeled Yes and No, and end boxes for dashboard redirect and error message.",
+      "expectations": [
+        "Output is valid Excalidraw JSON",
+        "Contains at least 4 shape elements plus a diamond (decision)",
+        "Diamond element is type ellipse or a shape indicating a decision",
+        "Two arrows from decision with labels Yes and No",
+        "Yes branch leads to a dashboard box",
+        "No branch leads to an error box",
+        "Layout flows in a logical direction (top-down or left-right)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Draw a C4 context diagram in Excalidraw for a payment SaaS: the main actors are Customer (person), our Payment Platform (system), Stripe (external payment provider), and SendGrid (external email service). Customer interacts with Payment Platform. Payment Platform calls Stripe and SendGrid.",
+      "expected_output": "Valid Excalidraw JSON with 4 elements: Customer (person/ellipse), Payment Platform (central large rectangle), Stripe (orange rectangle for external), SendGrid (orange rectangle for external), and 3 arrows connecting them with labels.",
+      "expectations": [
+        "Output is valid Excalidraw JSON",
+        "Customer element uses a person-like shape or labeled appropriately",
+        "Payment Platform is the central large element",
+        "Stripe and SendGrid use the external color scheme (orange)",
+        "3 arrows with labels showing interactions",
+        "All IDs unique and bindings valid"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Create a simple org chart in Excalidraw: CPO at top, then PM Lead and Design Lead on the next level (both reporting to CPO), then three PMs under PM Lead and two Designers under Design Lead.",
+      "expected_output": "Valid Excalidraw JSON with 7 boxes in a hierarchical layout: CPO at top center, PM Lead and Design Lead on level 2, PMs and Designers on level 3. Connecting lines from parent to children.",
+      "expectations": [
+        "Output is valid Excalidraw JSON",
+        "Contains exactly 7 elements (CPO + PM Lead + Design Lead + 3 PMs + 2 Designers)",
+        "CPO is positioned at top center",
+        "PM Lead and Design Lead are on the same level below CPO",
+        "3 PM boxes below PM Lead",
+        "2 Designer boxes below Design Lead",
+        "All parent-child connections present as lines or arrows"
+      ]
+    }
+  ]
+}

--- a/skills/excalidraw-diagram/evals/trigger-eval.json
+++ b/skills/excalidraw-diagram/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "excalidraw-diagram",
+  "description": "Triggers when the user wants to create a hand-drawn style diagram using Excalidraw",
+  "queries": [
+    { "id": 1, "query": "create an Excalidraw diagram for the system architecture", "should_trigger": true },
+    { "id": 2, "query": "draw a whiteboard-style sketch of the user registration flow", "should_trigger": true },
+    { "id": 3, "query": "excalidraw concept map with product strategy at the center", "should_trigger": true },
+    { "id": 4, "query": "sketch a C4 context diagram for our SaaS application", "should_trigger": true },
+    { "id": 5, "query": "hand-drawn architecture diagram for the microservices system", "should_trigger": true },
+    { "id": 6, "query": "draw an informal org chart for the product team in Excalidraw", "should_trigger": true },
+    { "id": 7, "query": "whiteboard diagram showing how the components interact", "should_trigger": true },
+    { "id": 8, "query": "create an Excalidraw file I can embed in my Obsidian note", "should_trigger": true },
+    { "id": 9, "query": "quick sketch of the three-tier web architecture", "should_trigger": true },
+    { "id": 10, "query": "draw a mind map in excalidraw with six branches", "should_trigger": true },
+    { "id": 11, "query": "create a mermaid flowchart for the login process", "should_trigger": false },
+    { "id": 12, "query": "add wikilinks to my Obsidian note", "should_trigger": false },
+    { "id": 13, "query": "create an Obsidian canvas layout with my strategy notes", "should_trigger": false },
+    { "id": 14, "query": "optimize my resume for a product manager role", "should_trigger": false },
+    { "id": 15, "query": "write a Python script to process image files", "should_trigger": false },
+    { "id": 16, "query": "summarize this YouTube video about design systems", "should_trigger": false },
+    { "id": 17, "query": "add frontmatter tags to this Obsidian note", "should_trigger": false },
+    { "id": 18, "query": "transcribe this audio recording to markdown", "should_trigger": false },
+    { "id": 19, "query": "analyze the competitive landscape for our product", "should_trigger": false },
+    { "id": 20, "query": "write a state machine diagram using mermaid stateDiagram-v2", "should_trigger": false }
+  ]
+}

--- a/skills/mermaid-diagram/README.md
+++ b/skills/mermaid-diagram/README.md
@@ -1,0 +1,81 @@
+# 📊 mermaid-diagram
+
+> Generate any Mermaid diagram from a plain-language description — flowcharts, sequence diagrams, class diagrams, state machines, mindmaps, Gantt charts, and more.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Content / Visualization                            |
+| Tags      | mermaid, diagram, flowchart, sequence, visualization, obsidian |
+| Risk      | Low                                                |
+
+## Overview
+
+`mermaid-diagram` translates a description — written in plain English — into syntactically correct Mermaid DSL wrapped in a fenced code block. The output renders natively in Obsidian, GitHub, GitLab, Notion, and any Markdown environment with Mermaid support.
+
+Supports 12 diagram types including flowcharts, sequence diagrams, state machines, ER diagrams, mindmaps, and Gantt charts.
+
+## Features
+
+- **12 diagram types** — flowchart, sequence, class, state, ER, mindmap, Gantt, pie, quadrant, git graph, timeline, XY chart
+- **Syntax validation** — mentally checks node ID references, subgraph closures, and arrow compatibility
+- **Smart type selection** — picks the most appropriate diagram type for the request
+- **Obsidian-native output** — uses the `mermaid` fence, which renders without plugins in Obsidian
+- **Subgraph grouping** — automatically suggests grouping for diagrams with 8+ nodes
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Draw a flowchart for..."
+- "Sequence diagram showing..."
+- "Create a class diagram for..."
+- "State machine for..."
+- "Mindmap of..."
+- "Gantt chart for the project timeline"
+- "Mermaid diagram of..."
+- "ER diagram for the database schema"
+
+## Requirements
+
+No tools or installation required. Mermaid is supported natively in:
+
+- **Obsidian** — built-in, no plugin needed
+- **GitHub / GitLab** — renders in `.md` files
+- **VS Code** — requires "Mermaid Preview" extension
+- **Browser** — use [mermaid.live](https://mermaid.live)
+
+## Diagram Types
+
+| Type | Best For |
+|------|---------|
+| `flowchart TD` | Step-by-step processes, decision trees |
+| `sequenceDiagram` | Actor interactions over time |
+| `classDiagram` | Object models, data schemas |
+| `stateDiagram-v2` | State machines, lifecycle flows |
+| `erDiagram` | Database schemas, data models |
+| `mindmap` | Topic hierarchies, brainstorms |
+| `gantt` | Project timelines, sprint planning |
+| `pie` | Proportional data |
+| `quadrantChart` | 2x2 priority matrices |
+| `gitGraph` | Branch and merge history |
+| `timeline` | Chronological events |
+| `xychart-beta` | Bar and line charts |
+
+## Examples
+
+| Request | Diagram Type |
+|---------|-------------|
+| "Draw the login flow" | `flowchart TD` |
+| "Show how the API handles requests" | `sequenceDiagram` |
+| "Model a blog with users and posts" | `classDiagram` |
+| "What states does an order go through?" | `stateDiagram-v2` |
+| "ER diagram for a CRM database" | `erDiagram` |
+| "Mindmap for product roadmap themes" | `mindmap` |
+| "Project timeline for Q2" | `gantt` |

--- a/skills/mermaid-diagram/SKILL.md
+++ b/skills/mermaid-diagram/SKILL.md
@@ -1,0 +1,478 @@
+---
+name: mermaid-diagram
+description: This skill should be used when the user needs to create, edit, or convert a diagram into Mermaid syntax. Use when the user asks for a flowchart, sequence diagram, class diagram, state diagram, entity-relationship diagram, mindmap, Gantt chart, or any other diagram type that Mermaid supports. Outputs a ready-to-render Mermaid code block.
+license: MIT
+---
+
+## Purpose
+
+This skill translates verbal or written descriptions of processes, architectures, data models, timelines, and relationships into correct Mermaid diagram syntax. The output is a fenced code block using the `mermaid` language identifier, which renders natively in Obsidian, GitHub, GitLab, Notion, and any modern Markdown environment.
+
+Mermaid is a text-based diagramming language. It allows diagrams to be version-controlled, diffed, and embedded directly in Markdown files without image uploads. This skill handles the translation from human intent to syntactically correct Mermaid DSL.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user asks to "draw", "create", "generate", or "diagram" something
+- The user provides a process flow, system architecture, or data model in prose and wants a visual representation
+- The user uploads or pastes an existing diagram image and wants its Mermaid equivalent
+- The user says "add a diagram to this note" without specifying a tool
+- The user explicitly mentions Mermaid, flowchart, sequence diagram, or any diagram type listed below
+- The user asks to revise or extend an existing Mermaid diagram
+- The user wants to visualize relationships between entities, steps in a process, or states in a system
+
+Do NOT use this skill when:
+
+- The user wants a hand-drawn or image-based diagram — Mermaid is text only
+- The user needs interactive diagrams with click handlers — use a JavaScript library instead
+- The user is working in Excalidraw — use `excalidraw-diagram` instead
+- The user wants a whiteboard-style canvas layout — use `obsidian-canvas` instead
+
+## Diagram Types Reference
+
+| Type | Keyword | Best for |
+|------|---------|---------|
+| Flowchart | `flowchart TD` / `graph LR` | Step-by-step processes, decision trees |
+| Sequence | `sequenceDiagram` | Interactions between actors over time |
+| Class | `classDiagram` | Object-oriented models, data schemas |
+| State | `stateDiagram-v2` | State machines, lifecycle flows |
+| Entity Relationship | `erDiagram` | Database schemas, data models |
+| Mindmap | `mindmap` | Topic hierarchy, brain dump structure |
+| Gantt | `gantt` | Project timelines, sprint planning |
+| Pie chart | `pie` | Proportional data visualization |
+| Quadrant chart | `quadrantChart` | 2x2 priority or positioning matrices |
+| Git graph | `gitGraph` | Branch and merge history |
+| Timeline | `timeline` | Chronological event sequences |
+| XY chart | `xychart-beta` | Bar and line chart data |
+
+## Workflow
+
+### Step 1: Identify the Diagram Type
+
+Read the user's request and select the most appropriate diagram type:
+
+- Processes with steps and decisions → `flowchart TD`
+- Two or more actors exchanging messages → `sequenceDiagram`
+- Classes, attributes, and methods → `classDiagram`
+- Something that transitions between states → `stateDiagram-v2`
+- Database tables and their relationships → `erDiagram`
+- A hierarchy of topics or concepts → `mindmap`
+- Tasks and dates on a timeline → `gantt`
+- Proportions of a whole → `pie`
+
+If the type is ambiguous, ask one clarifying question before generating: "What kind of diagram best fits your need — a flowchart, sequence diagram, or something else?"
+
+### Step 2: Extract the Diagram Content
+
+From the user's description, identify:
+
+- **Nodes / entities**: the main components (steps, actors, classes, states)
+- **Edges / relationships**: how nodes connect (arrows, labels, cardinality)
+- **Subgroups**: clusters, swimlanes, namespaces, or parent-child hierarchies
+- **Labels**: text on edges or inside nodes
+- **Conditions**: decision branches in flowcharts (`Yes` / `No` labels)
+
+### Step 3: Write Mermaid Syntax
+
+Apply the correct syntax for the chosen diagram type. Output the diagram inside a fenced code block:
+
+````markdown
+```mermaid
+<diagram code here>
+```
+````
+
+#### Flowchart
+
+```
+flowchart TD
+    A[Start] --> B{Decision}
+    B -- Yes --> C[Process A]
+    B -- No --> D[Process B]
+    C --> E[End]
+    D --> E
+```
+
+Node shapes:
+- `[Text]` — Rectangle (process, step)
+- `{Text}` — Diamond (decision)
+- `(Text)` — Rounded rectangle (start/end)
+- `((Text))` — Circle (connector)
+- `[/Text/]` — Parallelogram (input/output)
+- `[(Text)]` — Cylinder (database)
+
+Direction modifiers: `TD` (top-down), `LR` (left-right), `BT` (bottom-top), `RL` (right-left).
+
+Subgraphs for grouping:
+```
+flowchart TD
+    subgraph Backend
+        B1[API] --> B2[DB]
+    end
+    subgraph Frontend
+        F1[UI] --> F2[State]
+    end
+    F2 -->|HTTP| B1
+```
+
+#### Sequence Diagram
+
+```
+sequenceDiagram
+    actor User
+    participant App
+    participant DB
+
+    User->>App: Submit form
+    App->>DB: INSERT record
+    DB-->>App: OK
+    App-->>User: Success message
+```
+
+Arrow types:
+- `->>`  — Solid arrow with head (synchronous call)
+- `-->>`  — Dashed arrow with head (return / async)
+- `->`   — Solid line, open arrow
+- `-->`  — Dashed line, open arrow
+
+Activate/deactivate to show processing time:
+```
+sequenceDiagram
+    User->>+Server: Request
+    Server-->>-User: Response
+```
+
+Notes in sequence diagrams:
+```
+Note right of User: User is logged in
+Note over App,DB: Shared transaction
+```
+
+#### Class Diagram
+
+```
+classDiagram
+    class User {
+        +String name
+        +String email
+        -String password
+        +login() bool
+        +logout() void
+    }
+
+    class Order {
+        +int id
+        +Date createdAt
+        +List~Item~ items
+        +total() float
+    }
+
+    User "1" --> "0..*" Order : places
+```
+
+Visibility modifiers: `+` public, `-` private, `#` protected, `~` package/internal.
+
+Relationship types:
+- `-->` — Association
+- `--|>` — Inheritance
+- `..|>` — Implementation
+- `--*` — Composition
+- `--o` — Aggregation
+- `..>` — Dependency
+
+#### State Diagram
+
+```
+stateDiagram-v2
+    [*] --> Idle
+    Idle --> Processing : start
+    Processing --> Success : complete
+    Processing --> Failed : error
+    Success --> [*]
+    Failed --> Idle : retry
+
+    state Processing {
+        [*] --> Validating
+        Validating --> Executing
+        Executing --> [*]
+    }
+```
+
+Use `[*]` for entry and exit points. Nested states model sub-processes.
+
+#### Entity Relationship Diagram
+
+```
+erDiagram
+    USER {
+        int id PK
+        string name
+        string email UK
+    }
+    ORDER {
+        int id PK
+        int user_id FK
+        date created_at
+        float total
+    }
+    ORDER_ITEM {
+        int order_id FK
+        int product_id FK
+        int quantity
+    }
+    USER ||--o{ ORDER : "places"
+    ORDER ||--|{ ORDER_ITEM : "contains"
+```
+
+Cardinality notation:
+- `||` — exactly one
+- `o|` — zero or one
+- `}|` — one or more
+- `}o` — zero or more
+
+#### Mindmap
+
+```
+mindmap
+  root((Project))
+    Planning
+      Requirements
+      Timeline
+      Budget
+    Execution
+      Development
+      Testing
+      Deployment
+    Review
+      Metrics
+      Retrospective
+```
+
+Nodes use indentation to define hierarchy. Root node uses `(( ))` for a circle. Child nodes can use `[ ]`, `( )`, or plain text.
+
+#### Gantt Chart
+
+```
+gantt
+    title Project Timeline
+    dateFormat YYYY-MM-DD
+    section Planning
+        Requirements  :done, req, 2024-01-01, 2024-01-07
+        Design        :active, design, 2024-01-08, 7d
+    section Development
+        Backend       :backend, after design, 14d
+        Frontend      :frontend, after design, 14d
+    section Launch
+        Testing       :crit, test, after backend, 7d
+        Deploy        :deploy, after test, 1d
+```
+
+Task modifier keywords: `done`, `active`, `crit` (critical path), `milestone`.
+
+### Step 4: Validate the Syntax
+
+Before outputting, mentally trace through the diagram and check:
+
+1. **All referenced IDs exist** — every node ID used in an edge must be defined
+2. **Subgraph closures** — every `subgraph` has a matching `end`
+3. **Arrow syntax** — correct separator for the diagram type (`-->` vs `->>` vs `--|>`)
+4. **Special characters** — node labels with parentheses, brackets, or quotes must use `["label with (parens)"]` to avoid parse errors
+5. **No unsupported syntax** — mindmaps don't use arrows; ER diagrams use `||--o{` not `-->`
+
+If you detect a likely syntax issue, note it explicitly: `⚠️ Note: The backslash in the label may need escaping — if the diagram fails to render, replace it with a hyphen.`
+
+### Step 5: Provide Rendering Instructions
+
+After the code block, briefly note how to render:
+
+- **Obsidian**: The `mermaid` fence renders natively — no plugin required
+- **GitHub / GitLab**: Renders in `.md` files and wikis
+- **VS Code**: Install the "Mermaid Preview" extension
+- **Browser**: Use [mermaid.live](https://mermaid.live) to paste and preview
+
+If the skill detects the note is destined for Obsidian (user mentioned vault, note, or uses wikilinks), skip saying "Obsidian requires a plugin" — Mermaid is native to Obsidian.
+
+## Output Formats
+
+### Minimal Output
+
+For a simple diagram request, output only the fenced code block:
+
+````markdown
+```mermaid
+flowchart LR
+    A --> B --> C
+```
+````
+
+### Full Output
+
+For complex diagrams where context helps, include:
+
+1. A one-line description of what the diagram shows
+2. The fenced Mermaid code block
+3. Any notes about rendering or extension
+
+### Embedded in a Note
+
+When embedding in an Obsidian note, place the diagram after the relevant heading:
+
+```markdown
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    ...
+```
+
+The system is composed of three layers...
+```
+
+## Critical Rules
+
+**NEVER:**
+- Output diagram syntax without the ```` ```mermaid ```` fence — the diagram will not render
+- Mix diagram types in a single code block — use separate blocks for each diagram
+- Use HTML tags inside Mermaid nodes — Mermaid has limited HTML support; use plain text
+- Invent node IDs that don't match the connections — validate all references exist
+- Add a `direction` keyword inside `classDiagram` — it is not supported in all Mermaid versions
+- Use commas inside node labels without quoting: `A[Name, Title]` will break — use `A["Name, Title"]`
+
+**ALWAYS:**
+- Output the complete diagram, not a partial skeleton
+- Pick the diagram type that best conveys the user's mental model, not the easiest to generate
+- Include subgraph labels if the diagram has more than 8 nodes — group for readability
+- Limit nodes to 20 or fewer in a single diagram; suggest splitting if the user's request is larger
+- Test sequence diagram message labels — they appear above the arrow and must be concise
+- Use `stateDiagram-v2` instead of the older `stateDiagram` — the v2 syntax is more expressive
+
+## Example Usage
+
+**Example 1: Process flowchart from description**
+
+User: "Draw a flowchart for user login: user submits form, system checks credentials, if valid redirect to dashboard, if not show error"
+
+Output:
+````markdown
+```mermaid
+flowchart TD
+    A([User submits form]) --> B{Credentials valid?}
+    B -- Yes --> C[Redirect to dashboard]
+    B -- No --> D[Show error message]
+    D --> A
+```
+````
+
+---
+
+**Example 2: Sequence diagram for API interaction**
+
+User: "Show the sequence when a mobile app calls our REST API to get user data"
+
+Output:
+````markdown
+```mermaid
+sequenceDiagram
+    actor User
+    participant App as Mobile App
+    participant API as REST API
+    participant DB as Database
+
+    User->>App: Tap profile button
+    App->>+API: GET /users/{id}
+    API->>+DB: SELECT * FROM users
+    DB-->>-API: User record
+    API-->>-App: 200 OK { user }
+    App-->>User: Display profile
+```
+````
+
+---
+
+**Example 3: Class diagram for a data model**
+
+User: "Create a class diagram for a blog post system with users, posts, and comments"
+
+Output:
+````markdown
+```mermaid
+classDiagram
+    class User {
+        +int id
+        +String name
+        +String email
+        +createPost() Post
+        +leaveComment() Comment
+    }
+    class Post {
+        +int id
+        +String title
+        +String content
+        +Date publishedAt
+        +publish() void
+    }
+    class Comment {
+        +int id
+        +String body
+        +Date createdAt
+    }
+
+    User "1" --> "0..*" Post : authors
+    User "1" --> "0..*" Comment : writes
+    Post "1" --> "0..*" Comment : has
+```
+````
+
+---
+
+**Example 4: State machine for order status**
+
+User: "What are the states an order goes through from creation to delivery?"
+
+Output:
+````markdown
+```mermaid
+stateDiagram-v2
+    [*] --> Pending : Order created
+    Pending --> Confirmed : Payment received
+    Pending --> Cancelled : Customer cancels
+    Confirmed --> Shipped : Warehouse dispatched
+    Shipped --> Delivered : Carrier confirmed
+    Delivered --> [*]
+    Cancelled --> [*]
+    Shipped --> Returned : Customer requests return
+    Returned --> Refunded : Refund processed
+    Refunded --> [*]
+```
+````
+
+---
+
+**Example 5: Mindmap for a brainstorming session**
+
+User: "Create a mindmap for our product roadmap themes"
+
+Output:
+````markdown
+```mermaid
+mindmap
+  root((Product Roadmap))
+    Growth
+      Referral program
+      SEO improvements
+      Paid acquisition
+    Retention
+      Onboarding flow
+      In-app notifications
+      Loyalty rewards
+    Platform
+      Mobile app
+      API v2
+      Webhooks
+    Compliance
+      GDPR controls
+      Audit logs
+      Data export
+```
+````

--- a/skills/mermaid-diagram/evals/evals.json
+++ b/skills/mermaid-diagram/evals/evals.json
@@ -1,0 +1,86 @@
+{
+  "skill_name": "mermaid-diagram",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Draw a flowchart for a user registration process: user fills form, system validates email, if email taken show error and stop, otherwise hash password and save to DB, then send confirmation email.",
+      "expected_output": "A fenced ```mermaid code block containing a flowchart TD diagram with nodes for form filling, email validation, a decision diamond for email taken, password hashing, DB save, and confirmation email steps. Edges correctly labeled Yes/No on the decision branch.",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses flowchart TD or flowchart LR as the diagram type",
+        "Includes a decision diamond node for the email-taken check",
+        "Has two branches from the decision: one to error/stop, one to continue",
+        "Includes nodes for password hashing, DB save, and email confirmation",
+        "Node IDs used in edges are all defined"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create a sequence diagram showing how a mobile app authenticates a user via OAuth2: app redirects to provider, user logs in, provider returns auth code, app exchanges code for token, app calls API with token.",
+      "expected_output": "A fenced ```mermaid code block with a sequenceDiagram block containing actors (User, App, OAuth Provider, API) and the full OAuth2 authorization code flow with correct arrow types (->>, -->>).",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses sequenceDiagram as the diagram type",
+        "Defines at least 3 participants/actors",
+        "Shows the redirect from app to provider",
+        "Shows the auth code return",
+        "Shows token exchange",
+        "Shows API call with token",
+        "Uses ->> for requests and -->> for responses"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "I need a class diagram for an e-commerce system with Product, Cart, Order, and Customer classes. Products have name, price, stock. Cart contains items. Orders track status.",
+      "expected_output": "A fenced ```mermaid code block with a classDiagram showing 4 classes with appropriate attributes and relationships (Customer 1 to many Orders, Cart 1 to many Products, etc.)",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses classDiagram as the diagram type",
+        "Defines Product, Cart, Order, and Customer classes",
+        "Each class has at least 2 attributes",
+        "Includes at least 2 relationship lines between classes",
+        "Uses correct visibility modifiers (+ for public)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Create a mindmap for a content marketing strategy: topics should include Blog, Social Media, Email, and SEO, each with 2-3 subtopics.",
+      "expected_output": "A fenced ```mermaid code block with a mindmap diagram. Root node is Content Marketing Strategy. Four child branches for Blog, Social Media, Email, and SEO, each with 2-3 leaf nodes.",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses mindmap as the diagram type",
+        "Has a root node for the overall topic",
+        "Has at least 4 top-level branches",
+        "Each branch has 2-3 child nodes",
+        "Uses indentation correctly to define hierarchy (no arrows in mindmap)"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "What states can a support ticket go through? Start from Open, include Assigned, In Progress, Pending Response, Resolved, and Closed states.",
+      "expected_output": "A fenced ```mermaid code block with a stateDiagram-v2 block showing all 6 states, transitions between them with event labels, and [*] start and end points.",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses stateDiagram-v2 as the diagram type",
+        "Includes [*] as the initial state",
+        "Defines at least Open, Assigned, In Progress, Resolved, and Closed states",
+        "Adds transition labels explaining the trigger for each state change",
+        "Has a final [*] after Closed"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Make an ER diagram for a library system: Books have ISBN, title, and author. Members have name and email. Loans link a member to a book with a due date.",
+      "expected_output": "A fenced ```mermaid code block with an erDiagram block defining Book, Member, and Loan entities with their attributes and PK/FK designations, and relationship lines with cardinality notation.",
+      "expectations": [
+        "Output contains a ```mermaid fenced code block",
+        "Uses erDiagram as the diagram type",
+        "Defines Book entity with isbn (PK), title, author",
+        "Defines Member entity with id (PK), name, email",
+        "Defines Loan entity with FK references and due_date",
+        "Uses correct cardinality notation (||--o{, etc.)",
+        "Has at least 2 relationship lines"
+      ]
+    }
+  ]
+}

--- a/skills/mermaid-diagram/evals/trigger-eval.json
+++ b/skills/mermaid-diagram/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "mermaid-diagram",
+  "description": "Triggers when the user wants to create any kind of diagram using Mermaid syntax",
+  "queries": [
+    { "id": 1, "query": "draw a flowchart for the user registration process", "should_trigger": true },
+    { "id": 2, "query": "create a sequence diagram showing how the API handles a request", "should_trigger": true },
+    { "id": 3, "query": "I need a class diagram for my data model", "should_trigger": true },
+    { "id": 4, "query": "generate a mermaid state machine for the order lifecycle", "should_trigger": true },
+    { "id": 5, "query": "make a mindmap of the product strategy topics", "should_trigger": true },
+    { "id": 6, "query": "create an ER diagram for the database schema", "should_trigger": true },
+    { "id": 7, "query": "gantt chart for the Q3 project timeline", "should_trigger": true },
+    { "id": 8, "query": "diagram the architecture of our microservices", "should_trigger": true },
+    { "id": 9, "query": "show me the flow from login to checkout in a diagram", "should_trigger": true },
+    { "id": 10, "query": "visualize the states a document can be in using mermaid", "should_trigger": true },
+    { "id": 11, "query": "write me a Python script to parse CSV files", "should_trigger": false },
+    { "id": 12, "query": "summarize this YouTube video", "should_trigger": false },
+    { "id": 13, "query": "create an Excalidraw diagram for the system architecture", "should_trigger": false },
+    { "id": 14, "query": "optimize my resume for ATS", "should_trigger": false },
+    { "id": 15, "query": "add a wikilink to the Budget page in this note", "should_trigger": false },
+    { "id": 16, "query": "what is the best way to structure a REST API?", "should_trigger": false },
+    { "id": 17, "query": "create a canvas in Obsidian with my notes", "should_trigger": false },
+    { "id": 18, "query": "transcribe this audio file into markdown", "should_trigger": false },
+    { "id": 19, "query": "analyze the market for my startup idea", "should_trigger": false },
+    { "id": 20, "query": "write a cover letter for this job posting", "should_trigger": false }
+  ]
+}

--- a/skills/obsidian-automation/README.md
+++ b/skills/obsidian-automation/README.md
@@ -1,0 +1,75 @@
+# ⚙️ obsidian-automation
+
+> Automate Obsidian vault tasks using the Obsidian CLI, shell scripts, and the Local REST API. Batch-create notes, run maintenance, integrate with external tools.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Obsidian / Automation                              |
+| Tags      | obsidian, automation, cli, scripting, shell, batch-processing |
+| Risk      | Medium (file system operations)                    |
+
+## Overview
+
+`obsidian-automation` bridges Obsidian's visual interface and the command line, enabling batch operations that would be tedious through the GUI. It uses the Obsidian Local REST API (via the `obsidian-cli` npm package), shell scripting, and optional Templater plugin scripting. All destructive operations include a dry-run mode.
+
+## Features
+
+- **CLI integration** — Wrap the Obsidian Local REST API with commands for open, create, append, search
+- **Batch note creation** — Create multiple notes from a template with dynamic values
+- **Bulk frontmatter updates** — Update properties across an entire folder or vault
+- **Vault maintenance** — Archive old notes, generate index MOCs, clean up orphans
+- **Vault search** — Full-text search from the command line without opening Obsidian
+- **Shell recipes** — Ready-to-use scripts for common automation patterns
+- **Dry-run safety** — Preview changes before applying them
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Open today's daily note from the command line"
+- "Create meeting notes for all attendees"
+- "Batch-update the status field in all project notes"
+- "Automate my daily note creation"
+- "Archive notes older than 30 days"
+- "Obsidian CLI command to..."
+- "Script to generate an index of all my notes"
+
+## Requirements
+
+For full CLI automation:
+1. **Obsidian** running with the **Local REST API** community plugin installed
+2. **Node.js** installed
+3. `obsidian-cli` installed: `npm install -g obsidian-cli`
+4. API key configured: `export OBSIDIAN_API_KEY="your-key"` (found in plugin settings)
+
+For file-level automation (no Obsidian required):
+- Just a shell with standard Unix tools (`bash`, `find`, `grep`, `sed`, `awk`)
+
+## Automation Categories
+
+| Category | Tools Needed | Example |
+|---------|-------------|---------|
+| Navigate | obsidian-cli + Obsidian running | Open note, navigate |
+| Create | File ops or CLI | Batch note creation |
+| Update | Shell + CLI | Bulk frontmatter changes |
+| Search | CLI or grep | Vault-wide content search |
+| Maintain | Shell scripts | Archive, index, cleanup |
+| Integrate | CLI + external | Import from web, sync calendar |
+
+## Examples
+
+| Task | Command / Script |
+|------|-----------------|
+| Open today's daily note | `obsidian-cli open "Daily Notes/$(date +%Y-%m-%d)"` |
+| Append quick note to inbox | `obsidian-cli append "Inbox" --content "- $(date) — $NOTE"` |
+| Search vault | `obsidian-cli search "OKR"` |
+| Find notes without frontmatter | `grep -rL "^---" vault/**/*.md` |
+| Archive old notes | Script with `find -mtime +90` + `mv` to Archive folder |
+| Batch-create meeting notes | Loop over attendees list with `obsidian-cli put` |

--- a/skills/obsidian-automation/SKILL.md
+++ b/skills/obsidian-automation/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: obsidian-automation
+description: This skill should be used when the user wants to automate repetitive Obsidian tasks using the Obsidian CLI, shell commands, or scripted workflows. Use when the user needs to batch-create notes, bulk-update frontmatter, run vault maintenance tasks, open specific notes in Obsidian, navigate the vault programmatically, or integrate Obsidian with external tools.
+license: MIT
+---
+
+## Purpose
+
+This skill automates Obsidian vault operations that are tedious to perform manually through the GUI. It bridges the gap between Obsidian's visual interface and the command line, scripting layer, and external tools.
+
+Automation tasks include: opening notes and performing actions (insert template, navigate, toggle pins), reading vault metadata without opening Obsidian, batch creating or modifying notes, integrating vault content with other applications, and running scheduled maintenance scripts.
+
+The primary automation vector is the **Obsidian CLI** — a community-built command-line interface that communicates with Obsidian via its Local REST API plugin. Secondary automation paths include shell scripts operating on `.md` files directly, and native scripting with Obsidian's built-in Templater or DataviewJS plugins.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user wants to open a specific note in Obsidian from the command line
+- The user wants to programmatically insert text or templates into notes
+- The user needs to batch-process many notes at once (rename, update frontmatter, create from a list)
+- The user asks to automate a repetitive task they currently do manually in Obsidian
+- The user wants to integrate Obsidian with shell scripts, CI/CD, or other applications
+- The user needs vault-wide search or replace operations beyond what Obsidian's GUI offers
+- The user wants to run daily/weekly vault maintenance (archive old notes, generate indexes)
+- The user mentions "Obsidian CLI", "Local REST API", "obsidian-local-rest-api", or automation
+
+Do NOT use this skill when:
+
+- The task only requires editing a single note's content — edit the `.md` file directly
+- The user needs to change frontmatter properties on one note — use `obsidian-frontmatter` instead
+- The user is asking about wikilink management — use `obsidian-links` instead
+- The Obsidian CLI is not installed and the task does not require it (simple file operations can work without CLI)
+
+## Automation Tools Overview
+
+### Obsidian CLI (via Local REST API)
+
+The Obsidian Local REST API plugin exposes an HTTP API on `localhost:27123` (default). The `obsidian-cli` npm package wraps this API with a command-line interface.
+
+**Installation:**
+```bash
+# Install the Local REST API plugin in Obsidian (Community Plugins)
+# Then install the CLI wrapper:
+npm install -g obsidian-cli
+
+# Or use via npx:
+npx obsidian-cli --help
+```
+
+**Configuration:**
+```bash
+# Set the API key (found in Local REST API plugin settings)
+export OBSIDIAN_API_KEY="your-key-here"
+
+# Or pass per command:
+obsidian-cli --api-key "your-key" <command>
+```
+
+**Core commands:**
+```bash
+# Open a note
+obsidian-cli open "Daily Notes/2024-01-15"
+
+# Get note content
+obsidian-cli get "Projects/Project Alpha"
+
+# Create or update a note
+obsidian-cli put "Daily Notes/2024-01-15" --content "$(cat template.md)"
+
+# Append to a note
+obsidian-cli append "Daily Notes/2024-01-15" --content "- New task item"
+
+# Search the vault
+obsidian-cli search "query string"
+
+# List notes in a folder
+obsidian-cli list "Projects/"
+
+# Delete a note
+obsidian-cli delete "Archive/Old Note"
+```
+
+### Direct File Operations (Shell)
+
+Many vault tasks do not require the CLI and can be done with standard shell tools on the `.md` files directly:
+
+```bash
+# Find all notes lacking frontmatter
+grep -rL "^---" <vault-root>/*.md
+
+# Count notes by tag
+grep -rh "^  - " <vault-root>/**/*.md | sort | uniq -c | sort -rn | head 20
+
+# Update a frontmatter field across all notes in a folder
+find <vault-root>/Projects -name "*.md" -exec sed -i '' \
+  's/^status: planning$/status: active/' {} \;
+
+# Create a note if it does not exist
+NOTE="<vault-root>/Daily Notes/$(date +%Y-%m-%d).md"
+[[ ! -f "$NOTE" ]] && cat daily-template.md > "$NOTE"
+```
+
+### Templater Plugin (In-Vault Scripting)
+
+The Templater community plugin allows JavaScript execution inside note templates. Useful for:
+- Generating dynamic dates and wikilinks
+- Fetching external data (weather, calendar)
+- Prompting for user input during note creation
+
+Templater syntax:
+```
+<% tp.date.now("YYYY-MM-DD") %>
+<% tp.file.title %>
+<% await tp.system.prompt("Project name?") %>
+```
+
+## Workflow
+
+### Step 0: Detect Available Automation Tools
+
+Before scripting, determine what is available:
+
+```bash
+# Check if obsidian-cli is installed
+which obsidian-cli 2>/dev/null || npx obsidian-cli --version 2>/dev/null
+
+# Check if Obsidian is running (Local REST API must be active)
+curl -s http://localhost:27123/vault/ -H "Authorization: Bearer $OBSIDIAN_API_KEY" | head -5
+
+# Check Templater plugin (look for .js files in vault's scripts folder)
+find <vault-root> -name "*.js" -path "*/scripts/*" 2>/dev/null | head 5
+```
+
+If neither the CLI nor the Local REST API is available, tell the user:
+- "The Obsidian CLI requires the Local REST API plugin to be installed and Obsidian to be running."
+- Offer to proceed with direct file operations (no Obsidian required, works on `.md` files).
+
+### Step 1: Understand the Automation Goal
+
+Classify the task into one of these categories:
+
+| Category | Example tasks | Primary tool |
+|----------|-------------|-------------|
+| **Navigate** | Open a note, navigate to a heading | obsidian-cli |
+| **Create** | Batch-create notes from a list | file operations + CLI |
+| **Update** | Bulk update frontmatter fields | shell `sed` / CLI |
+| **Search** | Find notes by content or tag | CLI search / `grep` |
+| **Maintain** | Archive old notes, generate MOC | shell script |
+| **Integrate** | Sync with calendar, import from web | CLI + external tools |
+
+### Step 2: Generate the Automation Script
+
+For simple one-off tasks, output a single command. For multi-step automation, output a shell script with comments:
+
+```bash
+#!/usr/bin/env bash
+# Purpose: Create daily notes for the next 7 days from a template
+# Requirements: vault-root set, template.md exists
+# Usage: ./create-daily-notes.sh /path/to/vault /path/to/template.md
+
+VAULT="${1:?Usage: $0 <vault-root> <template>}"
+TEMPLATE="${2:?Usage: $0 <vault-root> <template>}"
+FOLDER="$VAULT/Daily Notes"
+
+mkdir -p "$FOLDER"
+
+for i in $(seq 0 6); do
+  DATE=$(date -v+${i}d +%Y-%m-%d 2>/dev/null || date -d "+${i} days" +%Y-%m-%d)
+  FILE="$FOLDER/$DATE.md"
+  if [[ ! -f "$FILE" ]]; then
+    sed "s/{{date}}/$DATE/g" "$TEMPLATE" > "$FILE"
+    echo "Created: $FILE"
+  else
+    echo "Exists:  $FILE (skipped)"
+  fi
+done
+```
+
+Key scripting principles:
+- Use `#!/usr/bin/env bash` shebang
+- Validate required arguments and environment variables at the top
+- Echo each action (created, updated, skipped) for visibility
+- Use `--dry-run` mode where possible before applying changes
+- Never operate on the vault without verifying `$VAULT` path
+
+### Step 3: Handle Obsidian-Specific Operations
+
+**Creating notes with proper frontmatter:**
+When scripting note creation, always write a complete frontmatter block at the top of the file template. Pass it through `sed` or `envsubst` to inject dynamic values.
+
+**Batch frontmatter updates:**
+Use `awk` or `python` for reliable YAML frontmatter manipulation. Avoid `sed` for multi-line YAML edits — it's error-prone.
+
+```python
+#!/usr/bin/env python3
+"""Update the status field in all project notes."""
+import os, re, sys
+
+vault = sys.argv[1]
+new_status = sys.argv[2]
+
+for root, dirs, files in os.walk(vault):
+    for f in files:
+        if not f.endswith('.md'): continue
+        path = os.path.join(root, f)
+        with open(path, 'r') as fp:
+            content = fp.read()
+        if not content.startswith('---'): continue
+        updated = re.sub(r'^status: \w+', f'status: {new_status}', content, flags=re.MULTILINE)
+        if updated != content:
+            with open(path, 'w') as fp:
+                fp.write(updated)
+            print(f"Updated: {path}")
+```
+
+**Vault maintenance — archive old notes:**
+```bash
+#!/usr/bin/env bash
+# Move notes not modified in 90+ days to Archive/
+VAULT="${1:?}"
+ARCHIVE="$VAULT/Archive"
+mkdir -p "$ARCHIVE"
+
+find "$VAULT" -name "*.md" -not -path "$ARCHIVE/*" -mtime +90 | while read -r f; do
+  echo "Archiving: $f"
+  mv "$f" "$ARCHIVE/$(basename "$f")"
+done
+```
+
+### Step 4: Dry-Run First
+
+Always offer a dry-run mode before making changes:
+- Add `echo "Would create: $FILE"` before actual operations
+- `--dry-run` flag pattern: check `[[ "$1" == "--dry-run" ]]` before writes
+- For destructive operations (delete, overwrite), default to dry-run unless `-f` flag is explicit
+
+### Step 5: Report Results
+
+At the end of any automation script, output a summary count:
+
+```
+Vault maintenance complete:
+  Notes created: 7
+  Notes updated: 23
+  Notes archived: 4
+  Errors: 0
+```
+
+## Common Automation Recipes
+
+**Open today's daily note in Obsidian:**
+```bash
+obsidian-cli open "Daily Notes/$(date +%Y-%m-%d)"
+```
+
+**Create a new note from a template:**
+```bash
+TITLE="Meeting with Alice - $(date +%Y-%m-%d)"
+obsidian-cli put "Meetings/$TITLE" --content "$(cat meeting-template.md)"
+obsidian-cli open "Meetings/$TITLE"
+```
+
+**Append to the inbox note:**
+```bash
+read -rp "Quick note: " QUICK_NOTE
+obsidian-cli append "Inbox" --content "- $(date +%H:%M) — $QUICK_NOTE"
+```
+
+**Find all notes without a status property:**
+```bash
+grep -rL "^status:" <vault-root>/**/*.md
+```
+
+**Generate an index of all project notes:**
+```bash
+echo "# Project Index\n" > "$VAULT/Projects/Index.md"
+find "$VAULT/Projects" -name "*.md" -not -name "Index.md" | sort | while read -r f; do
+  TITLE=$(basename "$f" .md)
+  echo "- [[$TITLE]]" >> "$VAULT/Projects/Index.md"
+done
+```
+
+## Critical Rules
+
+**NEVER:**
+- Run destructive operations (delete, overwrite, move) without a dry-run confirmation step
+- Hardcode the vault path in a script — always accept it as an argument or read from an environment variable
+- Modify binary files or non-`.md` files inside a vault directory
+- Use the Local REST API key in plain text in scripts committed to version control
+
+**ALWAYS:**
+- Check that Obsidian is running before using the CLI (the Local REST API must be active)
+- Validate the vault path exists before operating on it
+- Make a backup or test on a copy of the vault when running bulk modifications for the first time
+- Use the `--dry-run` pattern before applying irreversible changes
+- Document the script's purpose, requirements, and usage in a comment header
+
+## Example Usage
+
+**Example 1: Open today's daily note**
+
+User: "Open today's daily note."
+
+```bash
+obsidian-cli open "Daily Notes/$(date +%Y-%m-%d)"
+```
+
+If the note does not exist, create it from a template first:
+```bash
+DATE=$(date +%Y-%m-%d)
+NOTE="Daily Notes/$DATE"
+# Create if missing
+obsidian-cli list "$NOTE" 2>/dev/null || obsidian-cli put "$NOTE" --content "$(sed "s/{{date}}/$DATE/g" daily-template.md)"
+obsidian-cli open "$NOTE"
+```
+
+---
+
+**Example 2: Batch-create meeting notes**
+
+User: "Create meeting notes for Alice, Bob, and Carol scheduled for today."
+
+```bash
+DATE=$(date +%Y-%m-%d)
+for PERSON in "Alice" "Bob" "Carol"; do
+  TITLE="Meeting with $PERSON - $DATE"
+  obsidian-cli put "Meetings/$TITLE" \
+    --content "---
+title: $TITLE
+date: $DATE
+attendees:
+  - \"[[$PERSON]]\"
+tags:
+  - meeting
+status: scheduled
+---
+
+## Agenda
+
+## Notes
+
+## Action Items
+"
+  echo "Created: $TITLE"
+done
+```
+
+---
+
+**Example 3: Vault search from CLI**
+
+User: "Find all notes that mention 'OKR' in my vault."
+
+```bash
+obsidian-cli search "OKR"
+# Or with direct grep:
+grep -rl "OKR" <vault-root> --include="*.md"
+```
+
+---
+
+**Example 4: Archive old inbox items**
+
+User: "Move all items in my Inbox folder older than 2 weeks to the Archive."
+
+```bash
+find "$VAULT/Inbox" -name "*.md" -mtime +14 | while read -r f; do
+  DEST="$VAULT/Archive/$(basename "$f")"
+  echo "Archiving: $f → $DEST"
+  # Add --execute flag to actually move:
+  # mv "$f" "$DEST"
+done
+echo "Run with --execute to apply changes."
+```
+
+---
+
+**Example 5: Nightly maintenance script**
+
+User: "Create a nightly script that: creates tomorrow's daily note, appends today's done tasks to a weekly review note."
+
+Output: A full bash script with both operations, date calculations, template injection, and a summary log at the end.

--- a/skills/obsidian-automation/evals/evals.json
+++ b/skills/obsidian-automation/evals/evals.json
@@ -1,0 +1,68 @@
+{
+  "skill_name": "obsidian-automation",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Write a shell command to open today's daily note in Obsidian using the obsidian-cli. The daily notes are in a folder called 'Daily Notes' and the filename format is YYYY-MM-DD.md.",
+      "expected_output": "A shell command using obsidian-cli and the $(date +%Y-%m-%d) substitution to form the correct path and open the note.",
+      "expectations": [
+        "Uses obsidian-cli open",
+        "Constructs the path as Daily Notes/YYYY-MM-DD",
+        "Uses $(date +%Y-%m-%d) or equivalent to generate today's date",
+        "Command is a single runnable line or short block",
+        "Correctly quotes the path with spaces"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a bash script to batch-create meeting notes for 5 people: Alice Chen, Bob Martinez, Carol Lee, David Park, and Eve Torres. Each note should go in Meetings/, have a date of today, the person's name as an attendee wikilink, and tags: meeting, scheduled.",
+      "expected_output": "A bash script with a loop over the 5 names, using date command for today's date, obsidian-cli put or file creation to write each note with a frontmatter block, and echo output for each created note.",
+      "expectations": [
+        "Script has a shebang line (#!/usr/bin/env bash or #!/bin/bash)",
+        "Loops over all 5 names",
+        "Each note placed in Meetings/ folder",
+        "Frontmatter includes date (today), tags as multiline list, attendees as wikilinks",
+        "Echo or print for each created note",
+        "No hardcoded paths — uses a variable for the vault"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Write a shell command to search my entire Obsidian vault for all notes that contain the phrase 'action item'. Show results as a list of file paths.",
+      "expected_output": "A grep command or obsidian-cli search command that finds all .md files containing 'action item' and outputs their paths.",
+      "expectations": [
+        "Uses grep -rl or obsidian-cli search",
+        "Searches recursively in the vault",
+        "Filters for .md files only",
+        "Outputs file paths",
+        "Case handling mentioned or handled (case-insensitive flag)"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Create a bash script to archive all notes in the Inbox/ folder that have not been modified in more than 30 days. Move them to Archive/Inbox/. Include a dry-run mode that shows what would be moved without doing it.",
+      "expected_output": "A bash script with find -mtime +30, an Archive target directory, a dry-run mode (default), and an --execute flag to actually move files. Script prints each file being moved.",
+      "expectations": [
+        "Uses find with -mtime +30 to identify old files",
+        "Creates Archive/Inbox/ directory if it does not exist",
+        "Has dry-run default mode (prints without moving)",
+        "Has --execute or -f flag to apply actual moves",
+        "Prints each file being processed",
+        "Does not hardcode vault path — accepts as argument"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Write a script to append a quick note to my Obsidian Inbox note from the command line. The script should accept the note text as an argument, add the current timestamp, and append it as a bullet point.",
+      "expected_output": "A bash one-liner or short script using obsidian-cli append with the current time and provided text formatted as a Markdown bullet point.",
+      "expectations": [
+        "Accepts note text as an argument (or reads from stdin)",
+        "Prepends a timestamp using $(date) or similar",
+        "Formats as a Markdown bullet: '- HH:MM — note text'",
+        "Appends to a note called Inbox (or similar)",
+        "Uses obsidian-cli append or file append",
+        "Handles quoting of the argument string"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-automation/evals/trigger-eval.json
+++ b/skills/obsidian-automation/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-automation",
+  "description": "Triggers when the user needs to automate Obsidian tasks using the CLI, shell scripts, or batch operations",
+  "queries": [
+    { "id": 1, "query": "open today's daily note in Obsidian from the command line", "should_trigger": true },
+    { "id": 2, "query": "write a script to batch-create meeting notes for all my attendees", "should_trigger": true },
+    { "id": 3, "query": "automate daily note creation using the Obsidian CLI", "should_trigger": true },
+    { "id": 4, "query": "archive all inbox notes older than two weeks", "should_trigger": true },
+    { "id": 5, "query": "obsidian-cli command to append a quick note to my inbox", "should_trigger": true },
+    { "id": 6, "query": "find all notes in my vault that mention OKR using the command line", "should_trigger": true },
+    { "id": 7, "query": "batch update the status field in all project notes to done", "should_trigger": true },
+    { "id": 8, "query": "set up a nightly script to generate a project index note", "should_trigger": true },
+    { "id": 9, "query": "how do I use the Obsidian Local REST API to create notes programmatically?", "should_trigger": true },
+    { "id": 10, "query": "move all notes from Inbox to Projects folder in bulk", "should_trigger": true },
+    { "id": 11, "query": "add frontmatter tags to this note", "should_trigger": false },
+    { "id": 12, "query": "create a mermaid state diagram for the order lifecycle", "should_trigger": false },
+    { "id": 13, "query": "optimize my resume for software engineering roles", "should_trigger": false },
+    { "id": 14, "query": "add wikilinks to the people in this meeting note", "should_trigger": false },
+    { "id": 15, "query": "create an Excalidraw diagram for the architecture", "should_trigger": false },
+    { "id": 16, "query": "summarize this YouTube video", "should_trigger": false },
+    { "id": 17, "query": "write a Python REST API with FastAPI", "should_trigger": false },
+    { "id": 18, "query": "what is the best Zettelkasten workflow for students?", "should_trigger": false },
+    { "id": 19, "query": "create a cover letter for this product manager job", "should_trigger": false },
+    { "id": 20, "query": "transcribe this meeting recording to markdown notes", "should_trigger": false }
+  ]
+}

--- a/skills/obsidian-canvas/README.md
+++ b/skills/obsidian-canvas/README.md
@@ -1,0 +1,78 @@
+# 🗺️ obsidian-canvas
+
+> Create freeform visual workspaces in Obsidian Canvas. Arrange notes, text cards, images, and web content on an infinite canvas with hub-and-spoke, column, or Kanban layouts.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Obsidian / Knowledge Management                    |
+| Tags      | obsidian, canvas, visual-workspace, knowledge-map, dashboard |
+| Risk      | Low                                                |
+
+## Overview
+
+`obsidian-canvas` creates and edits Obsidian Canvas files (`.canvas`) — a native freeform visual workspace where notes become spatial cards on an infinite canvas. Unlike Mermaid (structured graph DSL) or Excalidraw (hand-drawn sketches), Canvas is a spatial navigation interface for your vault: each card is a live view of an actual note, preserving all links and content.
+
+Available natively in Obsidian since v1.1.0 — no plugins required.
+
+## Features
+
+- **Multiple node types** — text cards, file (note) cards, web iframes, grouping boxes
+- **Layout patterns** — hub-and-spoke, column, linear flow, nested clusters
+- **Color coding** — 6-color named palette + custom hex for nodes and edges
+- **Edges with labels** — directional arrows connecting cards with text labels
+- **Kanban boards** — column layout with status groups (Backlog, In Progress, Review, Done)
+- **Dashboard builder** — visual overview of projects, goals, or research areas
+- **JSON output** — complete `.canvas` file ready to save and open in Obsidian
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Create a canvas in Obsidian"
+- "Build a visual workspace for my projects"
+- "Map my notes spatially"
+- "Canvas dashboard for my areas of life"
+- "Obsidian canvas Kanban board"
+- "Create a hub-and-spoke canvas with these notes"
+- "Build a research workspace canvas"
+
+## Requirements
+
+- Obsidian version 1.1.0 or later (Canvas is a built-in core feature)
+- No plugins required
+- Vault path accessible for referencing existing notes as file cards
+
+## Layout Patterns
+
+| Pattern | Best For |
+|---------|---------|
+| Hub-and-spoke | Topic exploration, concept maps |
+| Column layout | Kanban boards, area dashboards |
+| Linear flow | Project roadmaps, sequential processes |
+| Nested clusters | Multi-project overviews, domain maps |
+
+## Canvas Node Type Reference
+
+| Type | Description |
+|------|-------------|
+| `text` | Rich text card (Markdown supported) |
+| `file` | Live embedded view of a `.md` or other vault file |
+| `link` | Embedded webpage (iframe) |
+| `group` | Colored bounding box for visual clustering |
+
+## Examples
+
+| Request | Canvas Layout |
+|---------|-------------|
+| "Dashboard for my three projects" | Three file cards in column layout with group boxes |
+| "Concept map for product strategy" | Hub-and-spoke with central text + 6 file cards |
+| "Brainstorming workspace for Q3 planning" | Four empty groups (Now/Next/Later/Ideas) |
+| "Research canvas for remote work topic" | Center note + 4 surrounding text cards |
+| "Kanban board for my tasks" | 4 column groups (Backlog/In Progress/Review/Done) |

--- a/skills/obsidian-canvas/SKILL.md
+++ b/skills/obsidian-canvas/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: obsidian-canvas
+description: This skill should be used when the user needs to create or edit an Obsidian Canvas — a freeform visual workspace that arranges notes, cards, links, images, and web content on an infinite canvas. Use when the user wants to map ideas spatially, build a knowledge dashboard, sketch a concept cluster, or create a visual workspace linking multiple Obsidian notes.
+license: MIT
+---
+
+## Purpose
+
+This skill creates and edits Obsidian Canvas files (`.canvas`) — a native Obsidian feature that provides an infinite, freeform visual workspace. Canvas is fundamentally different from both Mermaid diagrams (structured graph DSL) and Excalidraw (hand-drawn sketches): it is a spatial navigation interface for your vault, where notes become draggable cards that preserve their full content and linking behavior.
+
+On a Canvas, you can place:
+- **Note cards** — live views of existing `.md` files in the vault
+- **Text cards** — free-floating rich text blocks
+- **File cards** — images, PDFs, and other vault files displayed inline
+- **Web cards** — embedded iframes showing external URLs
+- **Groups** — colored bounding boxes that cluster related cards
+
+Canvas files are JSON with `.canvas` extension. They are rendered natively by Obsidian with no plugins required (available since Obsidian 1.1.0).
+
+## When to Use
+
+Invoke this skill when:
+
+- The user says "create a canvas" or "open canvas" in Obsidian
+- The user wants a visual workspace to see multiple notes side by side
+- The user wants to map relationships between notes spatially (rather than through links)
+- The user needs a "dashboard" view of their projects, goals, or areas of life
+- The user wants to plan a project by arranging note cards around a central concept
+- The user wants to brainstorm on an infinite canvas, creating text cards for each idea
+- The user is doing a research deep-dive and wants to lay out sources visually
+- The user mentions "spatial thinking", "concept cluster", "visual map of notes"
+
+Do NOT use this skill when:
+
+- The user wants a hand-drawn sketch whiteboard — use `excalidraw-diagram` instead
+- The user wants a structured flowchart or graph — use `mermaid-diagram` instead
+- The user wants to add wikilinks inside note content — use `obsidian-links` instead
+- The user is on Obsidian version earlier than 1.1.0 (Canvas is not available)
+
+## Canvas File Format
+
+Canvas files are JSON with the extension `.canvas`. Structure:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "node-1",
+      "type": "text",
+      "x": -200,
+      "y": -100,
+      "width": 250,
+      "height": 100,
+      "text": "Card content here"
+    },
+    {
+      "id": "node-2",
+      "type": "file",
+      "file": "Projects/Project Alpha.md",
+      "x": 100,
+      "y": -100,
+      "width": 300,
+      "height": 200
+    },
+    {
+      "id": "group-1",
+      "type": "group",
+      "x": -250,
+      "y": -150,
+      "width": 600,
+      "height": 300,
+      "label": "Group Label",
+      "color": "1"
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-1",
+      "fromNode": "node-1",
+      "fromSide": "right",
+      "toNode": "node-2",
+      "toSide": "left",
+      "label": "Connection label"
+    }
+  ]
+}
+```
+
+## Node Types
+
+| Type | Description | Required Fields |
+|------|-------------|----------------|
+| `text` | Floating rich text (Markdown) | `text`, `x`, `y`, `width`, `height` |
+| `file` | Embedded vault note or file | `file` (vault-relative path), `x`, `y`, `width`, `height` |
+| `link` | Embedded webpage iframe | `url`, `x`, `y`, `width`, `height` |
+| `group` | Colored grouping box | `x`, `y`, `width`, `height`, `label` (optional), `color` (optional) |
+
+## Edge Configuration
+
+Edges connect any two nodes with a labeled arrow:
+
+```json
+{
+  "id": "edge-1",
+  "fromNode": "source-node-id",
+  "fromSide": "bottom",
+  "toNode": "target-node-id",
+  "toSide": "top",
+  "label": "Arrow label",
+  "color": "4",
+  "fromEnd": "none",
+  "toEnd": "arrow"
+}
+```
+
+**Side values:** `top`, `bottom`, `left`, `right`  
+**End values:** `none` (no arrowhead), `arrow` (filled triangle)  
+**Colors:** `1` red, `2` orange, `3` yellow, `4` green, `5` cyan, `6` purple — or `"#hex"` for custom
+
+## Color System
+
+Obsidian Canvas uses a named color palette for nodes and edges:
+
+| Code | Color Name | Typical Use |
+|------|-----------|------------|
+| `"1"` | Red | Urgent / critical items |
+| `"2"` | Orange | In-progress / active |
+| `"3"` | Yellow | Ideas / to-review |
+| `"4"` | Green | Done / approved |
+| `"5"` | Cyan | Reference / resources |
+| `"6"` | Purple | Personal / goals |
+
+## Layout Patterns
+
+### Hub-and-Spoke
+
+Central concept node surrounded by related notes:
+- Central text card at `(0, 0)` with larger dimensions (300×150)
+- Related cards at radius ~400 in all directions
+- Arrows from center outward
+
+Use for: topic MOC, project overview, concept exploration
+
+### Column Layout
+
+Multiple vertical columns, each representing a category or status:
+- Column spacing: 350–400px
+- Cards stacked vertically in each column with 20–30px gaps
+- Group boxes around each column with color-coded labels
+
+Use for: Kanban boards, area-of-life dashboards, comparison views
+
+### Linear Flow
+
+Cards arranged left to right or top to bottom with arrows:
+- Horizontal: 350px between cards, all cards at same Y
+- Vertical: 250px between cards, all cards at same X
+- Edges connect each card to the next in sequence
+
+Use for: project roadmaps, process documentation, sequential thinking
+
+### Nested Clusters
+
+Groups of cards inside larger group boxes:
+- Use `group` nodes to visually bound clusters
+- Offset child nodes by ~30px inside group boundaries
+- Overlap allowed — groups are visual aids, not containers with collision
+
+Use for: multi-project dashboards, domain + subdomain mapping
+
+## Workflow
+
+### Step 0: Discover Vault Context
+
+1. Ask for the vault path if not known
+2. If the canvas references existing notes, verify the filenames:
+   ```bash
+   find <vault-root> -name "*.md" | grep -i "<search-term>"
+   ```
+3. Identify existing canvas files to avoid name conflicts:
+   ```bash
+   find <vault-root> -name "*.canvas"
+   ```
+
+### Step 1: Understand the Canvas Goal
+
+Classify the user's intent:
+
+| User goal | Layout pattern |
+|-----------|---------------|
+| "Overview of all my projects" | Column or hub-and-spoke |
+| "Visual workspace for this research topic" | Hub-and-spoke or freeform |
+| "Map out the relationships between these concepts" | Hub-and-spoke with edges |
+| "Brainstorm dashboard" | Column layout with text cards |
+| "See my notes on X side by side" | Grid layout with file cards |
+| "Project planning board" | Column layout (Kanban-style) |
+
+### Step 2: Plan the Canvas
+
+Before writing JSON, plan the positions:
+1. Choose the layout pattern
+2. List all nodes (type, label/file, dimensions)
+3. Plan groupings (which nodes cluster together?)
+4. Define edges (which nodes connect, in what direction, with what label?)
+5. Assign coordinate positions
+
+Standard card dimensions:
+- Text card (small): 200×100
+- Text card (medium): 300×150
+- File note card: 350×250 (shows note preview)
+- Wide banner card: 500×80
+- Group box: sized to contain its children with 30–40px padding
+
+### Step 3: Generate the Canvas JSON
+
+Write the complete `.canvas` JSON file. Ensure:
+- All node IDs are unique across nodes and edges
+- All `file` references use vault-relative paths (no leading `/`)
+- All edge `fromNode` and `toNode` values reference existing node IDs
+- Groups do not need to explicitly list their children — position and size define membership visually
+
+### Step 4: Output and Save Instructions
+
+Output the complete JSON in a fenced code block. Then instruct the user to:
+
+1. Save the file as `<Name>.canvas` in the Obsidian vault
+2. Open in Obsidian — it renders automatically with no plugins
+3. To edit: open the canvas and drag cards to reposition; click to edit text cards
+4. To add more notes: drag `.md` files from the file explorer onto the canvas
+
+## Critical Rules
+
+**NEVER:**
+- Reference a `file` path that does not exist in the vault without noting it as a placeholder
+- Use duplicate `id` values — all node and edge IDs must be unique
+- Reference an edge `fromNode` or `toNode` that is not in the nodes array
+- Default to Excalidraw or Mermaid when the user explicitly says "canvas"
+- Include non-canvas formatting instructions in the canvas JSON
+
+**ALWAYS:**
+- Output complete, valid JSON that can be saved directly as `.canvas`
+- Use vault-relative paths for `file` nodes (no absolute paths)
+- Assign meaningful IDs (e.g., `project-alpha-card`, `inbox-group`)
+- Include at least one edge if the canvas has conceptual relationships between nodes
+- Suggest an appropriate filename for the canvas (e.g., `Project Dashboard.canvas`)
+
+## Example Usage
+
+**Example 1: Project dashboard with three columns**
+
+User: "Create a canvas dashboard showing my three active projects: Project Alpha, Initiative X, and Research Sprint, each as a file card in their own column."
+
+Output: Canvas JSON with three file cards, one group per column with a label, and consistent vertical alignment. Filename suggestion: `Active Projects Dashboard.canvas`.
+
+---
+
+**Example 2: Hub-and-spoke concept map**
+
+User: "Create a canvas with 'Product Strategy' at the center, linked to six surrounding note cards: Vision, ICP, Positioning, Pricing, GTM, and Roadmap."
+
+Output: Canvas JSON with a central text card for Product Strategy, six file cards placed around it at consistent angles, and six arrows pointing outward from center. Color-coded edges by theme.
+
+---
+
+**Example 3: Brainstorming canvas**
+
+User: "Create a blank brainstorming canvas for our Q3 planning session with four groups: Now, Next, Later, and Ideas. Add a title card at the top."
+
+Output: Canvas JSON with one wide text card at the top as title, and four color-coded group boxes arranged in a 2×2 grid below. Groups are empty — ready for cards to be dropped in during the session.
+
+---
+
+**Example 4: Research deep-dive workspace**
+
+User: "Build a canvas for my deep research on remote work trends. Place the main note 'Remote Work Research.md' at center, and add empty text cards around it for: Key Statistics, Opposing Views, Supporting Evidence, Open Questions."
+
+Output: Canvas JSON with the central file card and four surrounding text cards with placeholder content and labeled headings. Edges pointing from the central card to each surrounding card.
+
+---
+
+**Example 5: Obsidian canvas Kanban board**
+
+User: "Create a Kanban canvas with four status columns: Backlog, In Progress, Review, Done. Add three card placeholders in Backlog."
+
+Output: Canvas JSON with four vertical group columns, three text cards in the Backlog column with placeholder task text, and appropriate color coding (gray for Backlog, orange for In Progress, yellow for Review, green for Done).

--- a/skills/obsidian-canvas/evals/evals.json
+++ b/skills/obsidian-canvas/evals/evals.json
@@ -1,0 +1,70 @@
+{
+  "skill_name": "obsidian-canvas",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create an Obsidian Canvas dashboard showing three active projects as file cards in separate columns: 'Projects/Project Alpha.md', 'Projects/Initiative X.md', and 'Projects/Research Sprint.md'. Add a column group for each card.",
+      "expected_output": "Valid .canvas JSON with 3 file nodes referencing the correct vault paths, 3 group nodes (one per column), positioned horizontally with consistent spacing. No edges required.",
+      "expectations": [
+        "Output is valid JSON with nodes and edges arrays",
+        "Contains exactly 3 file-type nodes",
+        "File paths correctly reference Projects/Project Alpha.md, Projects/Initiative X.md, Projects/Research Sprint.md",
+        "Contains 3 group nodes, one per column",
+        "Columns are horizontally spaced (x positions differ by at least 350)",
+        "All node IDs are unique"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create an Obsidian Canvas with a text card 'Product Strategy' at the center (position 0,0, size 300x150), and 4 surrounding file cards: 'Strategy/Vision.md', 'Strategy/ICP.md', 'Strategy/Pricing.md', 'Strategy/GTM.md'. Add edges from center to each surrounding card.",
+      "expected_output": "Valid .canvas JSON with 1 central text card, 4 file cards spaced around it, and 4 edges connecting center to each surrounding card.",
+      "expectations": [
+        "Output is valid JSON with nodes and edges arrays",
+        "Central text node at approximately (0, 0) with text 'Product Strategy'",
+        "4 file nodes with paths to Vision, ICP, Pricing, GTM notes",
+        "4 edge objects connecting the central node to each file card",
+        "All edge fromNode/toNode values reference valid node IDs",
+        "File cards are spread around the center (different x/y positions)"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create a Kanban canvas with 4 status columns: Backlog (gray), In Progress (orange), Review (yellow), Done (green). Each column should be a group box 300px wide and 600px tall. Add two sample text card tasks in the Backlog column.",
+      "expected_output": "Valid .canvas JSON with 4 group nodes using appropriate colors, positioned horizontally, and 2 text card nodes inside the Backlog group with placeholder task text.",
+      "expectations": [
+        "Output is valid JSON with nodes array",
+        "4 group-type nodes labeled Backlog, In Progress, Review, Done",
+        "Group colors approximately match the specified colors (gray/orange/yellow/green)",
+        "Groups are horizontally positioned with consistent spacing",
+        "2 text-type nodes with task content positioned within the Backlog group boundaries",
+        "All IDs unique"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Build a research workspace canvas centered on an existing note 'Research/Remote Work Trends.md'. Add 4 surrounding empty text cards with headers: '## Key Statistics', '## Opposing Views', '## Supporting Evidence', '## Open Questions'. Connect them to the center note with arrows.",
+      "expected_output": "Valid .canvas JSON with 1 file card for the main note, 4 text cards with the specified header text, and 4 edges from the file card to each text card.",
+      "expectations": [
+        "Output is valid JSON with nodes and edges arrays",
+        "1 file-type node referencing Research/Remote Work Trends.md",
+        "4 text-type nodes with the specified heading text",
+        "4 edges connecting the central file card to each text card",
+        "Text cards are spread around the center",
+        "All edge IDs and node IDs are unique"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Create a brainstorming canvas for a Q3 planning session. Add a title banner card 'Q3 Planning Session' at the top (wide, short). Below it, create 4 color-coded groups: Now (red), Next (orange), Later (cyan), Ideas (purple). Each group should be 280x400.",
+      "expected_output": "Valid .canvas JSON with 1 wide text banner card at the top, and 4 group nodes arranged in a 2×2 grid or horizontal row below, each with the correct color code and label.",
+      "expectations": [
+        "Output is valid JSON with nodes array",
+        "1 text node at the top with title content",
+        "4 group nodes labeled Now, Next, Later, Ideas",
+        "Colors match approximately: Now=red(1), Next=orange(2), Later=cyan(5), Ideas=purple(6)",
+        "Groups positioned below the title banner",
+        "All node IDs unique"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-canvas/evals/trigger-eval.json
+++ b/skills/obsidian-canvas/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-canvas",
+  "description": "Triggers when the user wants to create or edit an Obsidian Canvas file for visual spatial organization of notes",
+  "queries": [
+    { "id": 1, "query": "create an Obsidian canvas dashboard for my three active projects", "should_trigger": true },
+    { "id": 2, "query": "build a visual workspace in Obsidian to map my strategy notes spatially", "should_trigger": true },
+    { "id": 3, "query": "obsidian canvas Kanban board with Backlog, In Progress, and Done columns", "should_trigger": true },
+    { "id": 4, "query": "create a canvas file with a hub-and-spoke layout for my research topic", "should_trigger": true },
+    { "id": 5, "query": "brainstorming canvas for the Q3 planning session", "should_trigger": true },
+    { "id": 6, "query": "open a canvas in Obsidian with all my project notes arranged by status", "should_trigger": true },
+    { "id": 7, "query": "create an Obsidian canvas to show how my concept notes connect to each other", "should_trigger": true },
+    { "id": 8, "query": "build a .canvas file I can use as an area-of-life dashboard", "should_trigger": true },
+    { "id": 9, "query": "canvas layout with my meeting notes and a central weekly review file", "should_trigger": true },
+    { "id": 10, "query": "create a research workspace canvas for the remote work trends topic", "should_trigger": true },
+    { "id": 11, "query": "draw an Excalidraw whiteboard sketch of the system architecture", "should_trigger": false },
+    { "id": 12, "query": "create a mermaid mindmap for the product roadmap themes", "should_trigger": false },
+    { "id": 13, "query": "add wikilinks to the people mentioned in this meeting note", "should_trigger": false },
+    { "id": 14, "query": "fix the YAML frontmatter in this Obsidian note", "should_trigger": false },
+    { "id": 15, "query": "write a Python script to process CSV files", "should_trigger": false },
+    { "id": 16, "query": "summarize this YouTube tutorial video", "should_trigger": false },
+    { "id": 17, "query": "optimize my resume for a product manager role", "should_trigger": false },
+    { "id": 18, "query": "transcribe this audio file to markdown notes", "should_trigger": false },
+    { "id": 19, "query": "automate daily note creation using the Obsidian CLI", "should_trigger": false },
+    { "id": 20, "query": "generate a deep research report on remote work productivity", "should_trigger": false }
+  ]
+}

--- a/skills/obsidian-frontmatter/README.md
+++ b/skills/obsidian-frontmatter/README.md
@@ -1,0 +1,69 @@
+# 🏷️ obsidian-frontmatter
+
+> Create, validate, standardize, and repair YAML frontmatter properties in Obsidian notes. The schema layer of your knowledge base.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Obsidian / Knowledge Management                    |
+| Tags      | obsidian, frontmatter, yaml, properties, metadata, dataview |
+| Risk      | Low                                                |
+
+## Overview
+
+`obsidian-frontmatter` manages the YAML properties block at the top of every Obsidian note. It covers the complete lifecycle: writing well-formed frontmatter the first time, enforcing consistent schema across notes, updating stale properties, and repairing YAML that causes Obsidian parse errors. Consistent frontmatter is what makes Dataview queries accurate and vault-wide searches reliable.
+
+## Features
+
+- **Frontmatter creation** — Generate well-formed YAML blocks for any note type
+- **YAML repair** — Fix malformed frontmatter (tabs, inline lists, unquoted values)
+- **Schema standardization** — Apply consistent property templates across multiple notes
+- **Tag management** — Add, remove, or rename tags following Obsidian's hierarchy convention
+- **Alias management** — Add alternative note names for better link suggestions
+- **Type-specific templates** — Meeting, project, reference, daily note schemas
+- **Dataview-compatible** — Ensures properties are queryable by the Dataview plugin
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Add frontmatter to this note"
+- "Update the metadata in this note"
+- "Obsidian is showing a YAML error"
+- "Add tags to this note"
+- "Fix the properties in this file"
+- "Create a frontmatter template for project notes"
+- "Standardize metadata across all my meeting notes"
+
+## Requirements
+
+- An Obsidian vault with `.md` files
+- No special plugins required (core Properties feature in Obsidian)
+- Optional: Dataview plugin for querying properties
+
+## Property Schema Reference
+
+| Property | Type | Notes |
+|---------|------|-------|
+| `title` | Text | Human-readable note title |
+| `date` | Date | ISO 8601 `YYYY-MM-DD` |
+| `tags` | List | Multiline list, no inline format |
+| `aliases` | List | Alternative names for link suggestions |
+| `status` | Text | `draft`, `active`, `done`, `archived` |
+
+## Examples
+
+| Task | Description |
+|------|-------------|
+| Add metadata | "Add tags, date, and status to this meeting note" |
+| Fix YAML errors | "Obsidian shows a YAML parse error on this note" |
+| Standardize schema | "Apply the meeting note template to all notes in /Meetings" |
+| Add tags | "Add tags area/work and type/meeting to this note" |
+| Create template | "Create a frontmatter template for project notes" |
+| Fix inline tags | "Convert all inline tag arrays to multiline list format" |

--- a/skills/obsidian-frontmatter/SKILL.md
+++ b/skills/obsidian-frontmatter/SKILL.md
@@ -1,0 +1,343 @@
+---
+name: obsidian-frontmatter
+description: This skill should be used when the user needs to create, validate, standardize, or repair YAML frontmatter properties in Obsidian notes. Use when the user wants to add or update tags, aliases, dates, custom properties, or any metadata fields in the Properties panel of an Obsidian note.
+license: MIT
+---
+
+## Purpose
+
+This skill manages YAML frontmatter — the metadata block at the top of every Obsidian note, delimited by `---`. Obsidian calls these "Properties" and displays them in a structured panel. This skill covers the complete lifecycle of frontmatter: writing it correctly the first time, enforcing consistent schema across notes, updating stale properties, and repairing malformed YAML that causes Obsidian to show parsing errors.
+
+Frontmatter is how Obsidian notes become queryable. Without consistent, well-formed properties, Dataview queries fail, searches return incomplete results, and the vault's metadata structure erodes over time. This skill treats frontmatter as the schema layer of your knowledge base.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user wants to add a frontmatter block to a note that has none
+- The user wants to update a specific property (e.g., change the status, add a tag)
+- The user needs to standardize frontmatter across multiple notes to a shared schema
+- The user asks to "add properties", "update metadata", or "fix the frontmatter"
+- The user's note has a YAML parse error and Obsidian is not showing properties correctly
+- The user wants to add or remove items from a list property (like `tags` or `aliases`)
+- The user wants to set up a consistent template for a note type (meeting, project, daily note)
+- The user is building Dataview queries and needs to define which properties to use
+
+Do NOT use this skill when:
+
+- The user wants to manage wikilinks inside the note body — use `obsidian-links` instead
+- The user wants to create a complete note with full content — use `obsidian-note-builder` instead
+- The user is editing frontmatter in a non-Obsidian Markdown file (e.g., Jekyll, Hugo)
+
+## Frontmatter Syntax Reference
+
+Frontmatter must be the very first content in a file, with the opening `---` on line 1:
+
+```
+---
+title: My Note Title
+date: 2024-01-15
+tags:
+  - project
+  - active
+aliases:
+  - Alternative Title
+status: in-progress
+---
+```
+
+**Critical YAML rules:**
+- Opening `---` must be on line 1 with no preceding blank lines or characters
+- Use two-space indentation for list items (not tabs)
+- List items must use `- ` (dash + space) prefix
+- Never use inline list format for `tags`: `[tag1, tag2]` is invalid in Obsidian Properties
+- String values with colons should be quoted: `title: "My Note: A Subtitle"`
+- Boolean values: `true` / `false` (lowercase, no quotes)
+- Dates: ISO 8601 format `YYYY-MM-DD` — Obsidian stores them as date objects
+
+## Standard Property Schema
+
+### Core properties (recommended for all notes)
+
+| Property | Type | Description |
+|---------|------|-------------|
+| `title` | Text | Human-readable title (often matches filename) |
+| `date` | Date | Creation or primary date |
+| `tags` | List | Topics and categories for filtering |
+| `aliases` | List | Alternative names for link suggestions |
+| `status` | Text | Current state (e.g., `draft`, `active`, `done`) |
+
+### Extended properties (by note type)
+
+**Meeting notes:**
+```
+attendees:
+  - Name One
+  - Name Two
+date: 2024-01-15
+project: "[[Project Alpha]]"
+action_items:
+  - Task assigned to [[Person]]
+```
+
+**Project notes:**
+```
+status: active
+start_date: 2024-01-01
+due_date: 2024-03-31
+stakeholders:
+  - "[[Alice Chen]]"
+priority: high
+```
+
+**Reference / resource notes:**
+```
+source: "https://example.com/article"
+author: Author Name
+read_date: 2024-01-15
+rating: 4
+```
+
+**Daily notes:**
+```
+date: 2024-01-15
+mood: 7
+energy: 6
+focus_areas:
+  - Deep Work
+  - Exercise
+```
+
+## Workflow
+
+### Step 1: Inspect the Existing Note
+
+Read the note to determine its current state:
+
+1. Does the note have a frontmatter block? (starts with `---` on line 1?)
+2. Is the existing YAML well-formed? (no tab indentation, no duplicate keys, no unclosed strings)
+3. What properties already exist that should be preserved?
+4. What note type is this? (meeting, project, reference, daily, concept, MOC)
+
+If the note has a malformed frontmatter block, identify the specific error:
+- **Tabs instead of spaces** — replace with 2-space indent
+- **Inline list format** — convert `tags: [a, b]` to multiline list
+- **Duplicate keys** — keep the last value, remove duplicates
+- **Unquoted special characters** — add quotes around values with `:`, `#`, or `[`
+
+### Step 2: Determine the Target Schema
+
+Ask the user which note type this is if not clear from context. Use the appropriate template from the standard schema above. If the user has provided custom fields, include them.
+
+If updating an existing frontmatter block:
+- Preserve all existing properties not being changed
+- Add missing properties with sensible defaults
+- Never silently delete a property; if a property should be removed, confirm with the user
+
+### Step 3: Write or Update the Frontmatter Block
+
+Generate the complete updated frontmatter block. Rules:
+
+1. **Tags must be a YAML list** — never inline:
+   - ✅ Correct:
+     ```yaml
+     tags:
+       - project
+       - active
+     ```
+   - ❌ Wrong: `tags: [project, active]`
+
+2. **Aliases must be a YAML list:**
+   - ✅ Correct:
+     ```yaml
+     aliases:
+       - My Alternative Name
+     ```
+   - ❌ Wrong: `aliases: My Alternative Name`
+
+3. **Dates must be unquoted ISO 8601:**
+   - ✅ Correct: `date: 2024-01-15`
+   - ❌ Wrong: `date: "January 15, 2024"`
+
+4. **Wikilinks in frontmatter must be quoted:**
+   - ✅ Correct: `project: "[[Project Alpha]]"`
+   - ❌ Wrong: `project: [[Project Alpha]]`
+
+5. **No extra blank lines inside the frontmatter block**
+
+### Step 4: Replace the Frontmatter in the File
+
+When editing an existing note:
+
+1. Locate the existing frontmatter block (between first `---` pair)
+2. Replace the entire block including the `---` delimiters
+3. Preserve everything after the closing `---` exactly as written
+4. Output the complete updated note (or just the frontmatter change, whichever is more useful)
+
+When adding frontmatter to a note that has none:
+
+1. Insert the frontmatter block at line 1
+2. Do NOT add a blank line between the frontmatter and the first heading
+3. Preserve all existing content from line 1 onward (shift down by the frontmatter length)
+
+### Step 5: Validate the Output
+
+After generating the frontmatter, verify:
+
+- Opening `---` is on line 1
+- All required fields for the note type are present
+- `tags` and `aliases` are multiline YAML lists
+- No tab characters in the YAML block
+- No bare wikilinks (`[[...]]`) — they must be quoted strings
+- Dates are in `YYYY-MM-DD` format
+- String values with colons are quoted
+
+## Tag Naming Conventions
+
+Tags in Obsidian support hierarchy via `/`:
+- `#project/active` — nested tag for active projects
+- `#area/work` — area of life tag
+- `#resource/book` — resource type
+
+In frontmatter, tags are written without the `#` prefix:
+```yaml
+tags:
+  - project/active
+  - area/work
+  - resource/book
+```
+
+Recommended tag categories:
+- **Status:** `inbox`, `draft`, `active`, `done`, `archived`
+- **Type:** `meeting`, `project`, `concept`, `reference`, `daily`, `moc`
+- **Area:** `work`, `personal`, `learning`, `health`
+- **Topic:** domain-specific tags relevant to the vault's subject matter
+
+## Batch Operations
+
+When the user wants to standardize frontmatter across multiple notes:
+
+1. Identify the shared schema to apply
+2. List notes that are missing required properties
+3. Apply changes note by note, reporting each change
+4. Output a summary:
+
+```
+Updated 12 notes:
+  ✅ Added tags to: Meeting 2024-01-15.md, Project Alpha.md, ...
+  ✅ Fixed inline tags format in: Book Notes.md, Resource List.md
+  ⚠️  Skipped: Archive/Old Note.md (no changes needed)
+```
+
+## Critical Rules
+
+**NEVER:**
+- Use tab indentation in YAML — always use 2 spaces
+- Write tags or aliases on a single line: `tags: [a, b]` — always use the multiline list format
+- Add a blank line between the opening `---` and the first property
+- Add a blank line before the closing `---`
+- Remove existing properties without explicit user confirmation
+- Add frontmatter after the first heading — it must always be at the very top of the file
+- Use unquoted wikilinks as property values
+
+**ALWAYS:**
+- Preserve all existing properties when adding new ones
+- Use ISO 8601 dates (`YYYY-MM-DD`)
+- Follow the vault's existing tag naming convention if one can be detected
+- Suggest an `aliases` property if the note's title has common abbreviations or alternative names
+- Quote string values that contain `:`, `#`, or `[`
+
+## Example Usage
+
+**Example 1: Add frontmatter to a new meeting note**
+
+User: "Add metadata to this meeting note: attendees Alice Chen and Bob Martinez, project Project Alpha, date January 15 2024."
+
+Output:
+```yaml
+---
+title: Q2 Planning Kickoff
+date: 2024-01-15
+tags:
+  - meeting
+  - project/active
+attendees:
+  - "[[Alice Chen]]"
+  - "[[Bob Martinez]]"
+project: "[[Project Alpha]]"
+status: done
+---
+```
+
+---
+
+**Example 2: Fix malformed frontmatter**
+
+User: "Obsidian is showing a YAML error in this note. Here is the current frontmatter:"
+
+```
+---
+title: Strategy Note
+tags: [product, strategy, q2]
+date: March 2024
+project: [[Initiative X]]
+---
+```
+
+Issues found:
+1. `tags` uses inline list format — must be multiline
+2. `date` is not ISO 8601 format — should be `2024-03-01`
+3. `project` has an unquoted wikilink — must be quoted
+
+Fixed output:
+```yaml
+---
+title: Strategy Note
+tags:
+  - product
+  - strategy
+  - q2
+date: 2024-03-01
+project: "[[Initiative X]]"
+---
+```
+
+---
+
+**Example 3: Add a custom property to multiple notes**
+
+User: "Add `priority: high` to all my notes tagged with `project/active`."
+
+Response: Lists matching notes, confirms, then outputs the changes for each, preserving all existing properties.
+
+---
+
+**Example 4: Build a project note template**
+
+User: "Create a frontmatter template for all my project notes."
+
+Output:
+```yaml
+---
+title: Project Name
+date: YYYY-MM-DD
+status: planning
+priority: medium
+tags:
+  - project
+  - status/planning
+stakeholders:
+  - "[[Person Name]]"
+due_date: YYYY-MM-DD
+---
+```
+
+---
+
+**Example 5: Add tags to an existing note without touching the body**
+
+User: "Add tags 'area/work' and 'type/reference' to this note."
+
+1. Read the current frontmatter
+2. Append the two tags to the existing `tags` list (or create the `tags` field if absent)
+3. Output only the updated frontmatter block (not the full note) to minimize context

--- a/skills/obsidian-frontmatter/evals/evals.json
+++ b/skills/obsidian-frontmatter/evals/evals.json
@@ -1,0 +1,72 @@
+{
+  "skill_name": "obsidian-frontmatter",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add a frontmatter block to this meeting note:\n\n# Q2 Planning Kickoff\nAttendees: Alice Chen, Bob Martinez.\nWe reviewed the Q2 roadmap and assigned action items.\n\nUse date 2024-01-15, attendees as wikilinks, and tags: meeting, project/active.",
+      "expected_output": "The note with a YAML frontmatter block inserted at the top before the heading. Block includes title, date (2024-01-15), tags as a multiline list, and attendees as quoted wikilinks.",
+      "expectations": [
+        "Frontmatter block starts with --- on line 1",
+        "date field is ISO 8601 format: 2024-01-15",
+        "tags is a multiline YAML list (not inline [...])",
+        "tags include meeting and project/active",
+        "attendees listed as quoted wikilinks: \"[[Alice Chen]]\"",
+        "Closing --- present before the original note content",
+        "All original note content is preserved after the frontmatter"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Fix the YAML errors in this frontmatter:\n---\ntitle: Strategy Note\ntags: [product, strategy, q2]\ndate: March 2024\nproject: [[Initiative X]]\nstatus:\tactive\n---",
+      "expected_output": "A corrected frontmatter block: tags converted to multiline list, date converted to 2024-03-01, project wikilink quoted as \"[[Initiative X]]\", tab in status replaced with space.",
+      "expectations": [
+        "tags is a multiline list with - product, - strategy, - q2",
+        "date is 2024-03-01 in ISO 8601 format",
+        "project is quoted: \"[[Initiative X]]\"",
+        "status: active with no tab character",
+        "All original property keys are preserved",
+        "Opening and closing --- delimiters present"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Add the tags 'area/work' and 'type/reference' to this existing frontmatter without changing anything else:\n---\ntitle: Deep Work Notes\ndate: 2024-01-10\ntags:\n  - books\n  - productivity\nstatus: done\n---",
+      "expected_output": "The frontmatter block with two new tags appended to the existing tags list. All original fields (title, date, existing tags, status) preserved unchanged.",
+      "expectations": [
+        "area/work is added to the tags list",
+        "type/reference is added to the tags list",
+        "Original tags books and productivity are preserved",
+        "title, date, and status fields are unchanged",
+        "tags remains a multiline list format"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Create a reusable frontmatter template for project notes in our vault. Projects have a title, start and end dates, status (values: planning/active/on-hold/done), priority (low/medium/high), stakeholders (list of people), and a parent goal wikilink.",
+      "expected_output": "A YAML frontmatter template with placeholder values for all requested fields, using the correct types (dates in YYYY-MM-DD, lists for stakeholders, quoted wikilink for parent goal) and a status field with valid options noted.",
+      "expectations": [
+        "Includes title field",
+        "Includes start_date and due_date or end_date in YYYY-MM-DD format",
+        "Includes status field with placeholder or comment showing valid values",
+        "Includes priority field",
+        "Includes stakeholders as a multiline list",
+        "Includes a parent_goal or related field as a quoted wikilink",
+        "Template uses opening and closing --- delimiters"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "This note has no frontmatter and needs to be prepared for Dataview queries. The note is about a book called 'Deep Work' by Cal Newport, I read it in January 2024, would rate it 5/5, and it has themes of focus, productivity, and deep work.\n\n# Deep Work — Notes\nMy notes on the book by Cal Newport...",
+      "expected_output": "The note with a well-formed frontmatter block including title, author, read_date (2024-01-01 or similar), rating (5), and tags as a multiline list with relevant themes. Original note body preserved.",
+      "expectations": [
+        "Frontmatter block inserted at line 1",
+        "title field contains 'Deep Work'",
+        "author field contains 'Cal Newport'",
+        "read_date is in ISO 8601 format",
+        "rating is a number (5)",
+        "tags is a multiline list including focus, productivity, and/or deep-work",
+        "Original note heading and body preserved after closing ---"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-frontmatter/evals/trigger-eval.json
+++ b/skills/obsidian-frontmatter/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-frontmatter",
+  "description": "Triggers when the user needs to create, fix, or manage YAML frontmatter properties in Obsidian notes",
+  "queries": [
+    { "id": 1, "query": "add frontmatter to this meeting note with date, attendees, and tags", "should_trigger": true },
+    { "id": 2, "query": "Obsidian is showing a YAML parse error on this note", "should_trigger": true },
+    { "id": 3, "query": "fix the inline tags in this frontmatter to use the multiline list format", "should_trigger": true },
+    { "id": 4, "query": "add the tags area/work and type/reference to this note properties", "should_trigger": true },
+    { "id": 5, "query": "create a frontmatter template for my project notes", "should_trigger": true },
+    { "id": 6, "query": "update the status field in this note to done", "should_trigger": true },
+    { "id": 7, "query": "standardize the metadata across all my meeting notes in the Meetings folder", "should_trigger": true },
+    { "id": 8, "query": "add an aliases field to this note with two alternative names", "should_trigger": true },
+    { "id": 9, "query": "prepare this note for Dataview queries with proper frontmatter", "should_trigger": true },
+    { "id": 10, "query": "the date in my frontmatter is in the wrong format, fix it to ISO 8601", "should_trigger": true },
+    { "id": 11, "query": "add wikilinks between my product notes and the strategy MOC", "should_trigger": false },
+    { "id": 12, "query": "create a mermaid flowchart for the deployment process", "should_trigger": false },
+    { "id": 13, "query": "write a Python script to process CSV files", "should_trigger": false },
+    { "id": 14, "query": "summarize this YouTube video for me", "should_trigger": false },
+    { "id": 15, "query": "create an Excalidraw diagram for the system architecture", "should_trigger": false },
+    { "id": 16, "query": "optimize my LinkedIn profile headline", "should_trigger": false },
+    { "id": 17, "query": "how do I structure my Obsidian vault for a Zettelkasten system?", "should_trigger": false },
+    { "id": 18, "query": "create an Obsidian canvas with my strategy notes", "should_trigger": false },
+    { "id": 19, "query": "build a new note about product discovery principles", "should_trigger": false },
+    { "id": 20, "query": "transcribe this audio file", "should_trigger": false }
+  ]
+}

--- a/skills/obsidian-links/README.md
+++ b/skills/obsidian-links/README.md
@@ -1,0 +1,70 @@
+# 🔗 obsidian-links
+
+> Create, validate, repair, and analyze wikilinks in Obsidian vaults. Builds knowledge graphs through intentional bidirectional linking.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Obsidian / Knowledge Management                    |
+| Tags      | obsidian, wikilinks, knowledge-graph, backlinks, MOC |
+| Risk      | Low                                                |
+
+## Overview
+
+`obsidian-links` manages the core linking primitive of Obsidian — `[[wikilinks]]` — as an information architecture task rather than a formatting task. Every link represents a relationship between ideas, and this skill ensures those relationships are intentional, bidirectional where appropriate, and always resolvable to a real note.
+
+## Features
+
+- **Link creation** — Insert wikilinks into existing notes with correct syntax
+- **Broken link detection** — Find links that point to non-existent notes or invalid block IDs
+- **Orphaned note discovery** — Identify notes with no incoming links
+- **Auto-linking** — Convert plain text mentions to wikilinks
+- **Map of Content (MOC) builder** — Aggregate related notes into organized index notes
+- **Bidirectional link guidance** — Suggest reverse links for significant relationships
+- **Block ID linking** — Create and validate links to specific blocks (`^block-id`)
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Add wikilinks to this note"
+- "Find broken links in my vault"
+- "Which notes are orphaned?"
+- "Link the Strategy note to the OKR Tracker"
+- "Build a MOC for all my product notes"
+- "Convert mentions to wikilinks"
+- "Check backlinks for this note"
+
+## Requirements
+
+- An Obsidian vault (folder of `.md` files)
+- Vault path accessible by the AI tool
+- Optional: Obsidian open for live preview (not required for link creation/validation)
+
+## Wikilink Syntax Quick Reference
+
+| Syntax | Meaning |
+|--------|---------|
+| `[[Note Name]]` | Link to note |
+| `[[Note Name\|Display Text]]` | Link with custom text |
+| `[[Note Name#Heading]]` | Link to a heading |
+| `[[Note Name#^blockid]]` | Link to a block |
+| `![[Note Name]]` | Embed full note |
+| `![[Note Name#Heading]]` | Embed a section |
+
+## Examples
+
+| Task | Example |
+|------|---------|
+| Add links to meeting notes | "Add wikilinks to the people and projects in this meeting note" |
+| Validate links | "Check Research hub.md for broken links" |
+| Find orphans | "Which notes in my vault have no incoming links?" |
+| Connect two notes | "Link the Product Strategy note to the OKR Tracker" |
+| Build MOC | "Create a MOC for all my notes about product management" |
+| Auto-link | "Convert all mentions of 'Deep Work' to wikilinks in this note" |

--- a/skills/obsidian-links/SKILL.md
+++ b/skills/obsidian-links/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: obsidian-links
+description: This skill should be used when the user needs to create, validate, repair, or analyze wikilinks inside an Obsidian vault. Use when the user wants to add links between notes, find broken links, rename a linked note, discover orphaned notes, or build a bidirectional linking structure in Obsidian.
+license: MIT
+---
+
+## Purpose
+
+This skill manages wikilinks — the `[[double bracket]]` linking syntax that is the core navigation primitive in Obsidian. It covers creating new links, validating that target notes exist, repairing broken links after renames, discovering unlinked mentions, and building Dataview-compatible linking patterns.
+
+Wikilinks are what make a vault a knowledge graph. This skill treats linking not as a formatting task but as an information architecture task: every link represents a relationship between ideas, and that relationship should be intentional, bidirectional where appropriate, and always resolvable to a real note.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user wants to add wikilinks to an existing note
+- The user has renamed a note and needs to find all references to update
+- The user asks to find broken links (links that point to notes that do not exist)
+- The user wants to find all notes that link to a particular note (backlinks)
+- The user asks to discover "orphaned notes" (notes with no incoming links)
+- The user asks to convert plain text mentions of a note name into wikilinks
+- The user wants to create a new note and automatically link it from another note
+- The user asks to build a Map of Content (MOC) that aggregates links to related notes
+- The user wants to understand the link structure of a vault or a section of it
+
+Do NOT use this skill when:
+
+- The user wants to format the frontmatter properties of a note — use `obsidian-frontmatter` instead
+- The user wants to create a new note from scratch with full content — use `obsidian-note-builder` instead
+- The user is linking to external URLs — those use standard Markdown `[text](url)` syntax, not wikilinks
+- The user is working in a Markdown environment other than Obsidian
+
+## Wikilink Syntax Reference
+
+| Syntax | Result |
+|--------|--------|
+| `[[Note Name]]` | Link to a note. Displays the note name as text. |
+| `[[Note Name\|Display Text]]` | Link to a note with custom display text. |
+| `[[Note Name#Heading]]` | Link to a specific heading within a note. |
+| `[[Note Name#^blockid]]` | Link to a specific block by its block ID. |
+| `[[#Heading in current note]]` | Link to a heading in the current note. |
+| `[[ ]]` with just a space | Creates an "empty" link — avoid this. |
+| `![[Note Name]]` | Embed (transclude) the entire note inline. |
+| `![[Note Name#Heading]]` | Embed only the section under that heading. |
+
+**Block IDs:** A block ID is a unique identifier appended to any line or paragraph:
+```
+This is a paragraph I want to reference. ^my-block-id
+```
+
+Then link to it from another note: `[[My Note#^my-block-id]]`
+
+Block IDs must be:
+- Lowercase letters, numbers, and hyphens only
+- Appended with a space and `^` before the ID
+- Placed at the end of the line they identify
+
+## Workflow
+
+### Step 0: Discover the Vault Structure
+
+Before adding or validating links, identify the vault's file layout:
+
+1. Check if a vault root has been specified. If not, ask: "Which folder is your Obsidian vault root?"
+2. List the top-level folders to understand the note organization (`ls -1 <vault-root>/`)
+3. If the user mentions a specific note, confirm it exists: `find <vault-root> -name "*.md" | grep -i "<note-name>"`
+4. Note whether the vault uses a flat structure or nested folders, as this affects link resolution
+
+### Step 1: Identify the Task
+
+Determine which link operation the user needs:
+
+| User request | Task |
+|-------------|------|
+| "Add links to this note" | **Create links**: Insert wikilinks into specific text |
+| "Fix broken links" | **Validate & repair**: Find links whose target does not exist |
+| "Find orphans" | **Audit**: List notes with no incoming links |
+| "Convert mentions to links" | **Autolink**: Replace plain-text note names with wikilinks |
+| "Build a MOC" | **Aggregate**: Create or update a Map of Content note |
+| "Link this to that" | **Connect**: Create a specific link between two named notes |
+
+### Step 2: Create Links
+
+When creating wikilinks in an existing note:
+
+1. Read the target note to identify existing headings and blocks
+2. Match user intent to the correct link form:
+   - Link to the full note → `[[Note Name]]`
+   - Link with custom text → `[[Note Name|Anchor Text]]`
+   - Link to a specific section → `[[Note Name#Heading]]`
+3. Insert the link at the appropriate position in the source note without altering surrounding text
+4. If the target note does not exist and the user intends to create it, create the note first (minimal stub: title heading + empty body) then insert the link
+
+**Text replacement rule:** When converting a plain-text mention to a wikilink, replace the entire phrase that matches the note name, not partial words. "Project Alpha" → `[[Project Alpha]]`, but "project alphanumeric" should NOT be auto-linked.
+
+### Step 3: Validate Links
+
+To check that all wikilinks in a note (or vault) resolve to existing files:
+
+1. Extract all `[[...]]` patterns from the source file(s)
+2. For each link, extract the note name (strip `#heading`, `|display text`, `!` prefix)
+3. Search the vault for a matching `.md` file: `find <vault-root> -iname "<note-name>.md"`
+4. Report broken links in a table:
+
+| Source note | Broken link | Reason |
+|------------|-------------|--------|
+| `Weekly Review.md` | `[[Team Meeting Notes]]` | No matching file found |
+| `Project Alpha.md` | `[[Budget 2023#^block1]]` | Note exists but block ID not found |
+
+5. For each broken link, suggest the most likely fix based on approximate filename matching
+
+### Step 4: Find Orphaned Notes
+
+Orphaned notes are Markdown files that no other note links to. To find them:
+
+```bash
+# List all .md files in the vault
+find <vault-root> -name "*.md" > /tmp/all_notes.txt
+
+# Extract all wikilink targets from all notes
+grep -roh "\[\[.*\]\]" <vault-root> | sed 's/\[\[//;s/\]\]//;s/|.*//' | sort -u > /tmp/all_linked.txt
+
+# Notes not referenced anywhere
+comm -23 <(sort /tmp/all_notes.txt | xargs -I{} basename {} .md) /tmp/all_linked.txt
+```
+
+Present orphans in a list and suggest:
+- Adding links from a related note
+- Adding the orphan to a MOC
+- Deleting the note if it contains no useful content
+
+### Step 5: Build a Map of Content (MOC)
+
+A MOC is an index note that provides a navigable entry point to a topic cluster. To build or update a MOC:
+
+1. Identify the topic's core note (often the same name as the folder or tag)
+2. Find all notes related to the topic (by filename pattern, tag, or folder)
+3. Group related notes into logical sections
+4. Generate a MOC note with this structure:
+
+```markdown
+# <Topic> — Map of Content
+
+## Foundational Concepts
+- [[Note A]] — one-line description
+- [[Note B]] — one-line description
+
+## Reference Material
+- [[Note C]]
+- [[Note D]]
+
+## Active Projects
+- [[Project Note 1]]
+- [[Project Note 2]]
+
+## Related Topics
+- [[Adjacent MOC 1]]
+- [[Adjacent MOC 2]]
+```
+
+### Step 6: Implement Bidirectional Links
+
+Obsidian tracks backlinks automatically — you do not need to manually add "see also: [[this note]]" in both directions. However, for important relationships, explicit bidirectional linking improves navigability:
+
+1. Add the forward link in the source note: `[[Target]]`
+2. If the relationship is significant, add a `## Related` section or update the frontmatter `aliases` in the target note to acknowledge the connection
+
+For parent-child relationships (a concept note and its sub-notes), use embeds rather than links when you want the content of child notes to appear inline in the parent.
+
+## Link Naming Conventions
+
+- Use the exact filename (without `.md`) as the link target
+- Note names are case-sensitive in Obsidian on some systems — use exact capitalization
+- If the vault has notes with identical names in different folders, qualify the path: `[[folder/Note Name]]`
+- Prefer human-readable note names over codes: `[[Q1 OKRs]]` is better than `[[OKR_2024_Q1_v3]]`
+- Avoid special characters in note names that could break links: `/`, `?`, `#`, `^`, `[`, `]`, `|`, `\`
+
+## Critical Rules
+
+**NEVER:**
+- Create a wikilink to a note that does not exist unless the user explicitly asks to create the note as well
+- Auto-link every occurrence of a word — only link the first meaningful mention per section
+- Change the link target to fix a display issue; change the display text `[[Target|Different Text]]` instead
+- Use wikilinks for external URLs — those always use `[text](https://...)` syntax
+- Embed images using wikilinks unless the image exists in the vault: `![[image.png]]` only if the file is there
+
+**ALWAYS:**
+- Verify the target note exists before inserting a wikilink (or note that it will be created)
+- Preserve all existing content when inserting links — never delete paragraphs to make room
+- Use the exact note name (case-sensitive) as the link target
+- Suggest adding a backlink when creating a forward link if the relationship is bidirectional
+- Report broken link counts at the end of a validation scan, not just the list
+
+## Example Usage
+
+**Example 1: Add wikilinks to a meeting note**
+
+User: "I wrote meeting notes for the Q2 Planning session. Please add wikilinks to the people and projects mentioned."
+
+Workflow:
+1. Read the meeting note content
+2. Identify proper nouns that match existing note names (team member names, project names)
+3. Insert wikilinks for each, using display text where names are abbreviated
+
+Output:
+```markdown
+Attendees: [[Alice Chen]], [[Bob Martinez]], [[Team Lead]], Sara (no note found — skipping)
+
+Discussed: [[Project Alpha]] timeline slip, budget review for [[Initiative X]], and follow-up on [[Q1 Retrospective]].
+```
+
+---
+
+**Example 2: Find broken links in a note**
+
+User: "Check my Research hub note for broken links."
+
+Output:
+```
+Scanning Research hub.md for broken links...
+
+✅ [[Deep Work]] — found
+✅ [[Atomic Habits]] — found
+❌ [[Focus Techniques]] — no matching note in vault
+❌ [[Reading List 2024#^morning-reads]] — note exists but block ID not found
+
+2 broken links found.
+
+Suggested fixes:
+- [[Focus Techniques]] → Did you mean [[Focus and Productivity]]? (closest match found)
+- Remove the ^morning-reads block reference or add the block ID to Reading List 2024.md
+```
+
+---
+
+**Example 3: Create a link between two notes**
+
+User: "Link the Product Strategy note to the OKR Tracker note."
+
+1. Verify both notes exist
+2. Add to Product Strategy.md: `See also: [[OKR Tracker]]`
+3. Optionally add reverse link in OKR Tracker.md under a `## Related` section
+
+---
+
+**Example 4: Find orphaned notes**
+
+User: "Which notes in my vault have no incoming links?"
+
+Output:
+```
+Orphaned notes (not linked from anywhere):
+
+- Ideas Dump.md
+- Temp Notes.md
+- API Reference v2.md
+- Meeting 2024-09-14.md
+
+Suggestions:
+- Add [[API Reference v2]] to your Developer Resources MOC
+- Archive or delete Temp Notes.md if no longer needed
+```
+
+---
+
+**Example 5: Build a Map of Content**
+
+User: "Create a MOC for all my notes about Product Management."
+
+1. Search for notes tagged `#product` or in a `Product/` folder
+2. Group by type (concepts, reference, meetings, projects)
+3. Output a complete MOC note with all links organized into sections

--- a/skills/obsidian-links/evals/evals.json
+++ b/skills/obsidian-links/evals/evals.json
@@ -1,0 +1,69 @@
+{
+  "skill_name": "obsidian-links",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add wikilinks to the following meeting note. The vault contains notes named 'Alice Chen', 'Bob Martinez', 'Project Alpha', and 'Q2 Planning'.\n\nMeeting: Q2 Planning Kickoff\nAttendees: Alice Chen, Bob Martinez.\nWe discussed Project Alpha timeline and the agenda for Q2 Planning.",
+      "expected_output": "The meeting note with [[Alice Chen]], [[Bob Martinez]], [[Project Alpha]], and [[Q2 Planning]] inserted as wikilinks around the matching plain-text names.",
+      "expectations": [
+        "Alice Chen is wrapped in [[Alice Chen]]",
+        "Bob Martinez is wrapped in [[Bob Martinez]]",
+        "Project Alpha is wrapped in [[Project Alpha]]",
+        "Q2 Planning is wrapped in [[Q2 Planning]]",
+        "No other text is modified",
+        "Output uses correct [[double bracket]] syntax"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Check this note for broken links. The vault only contains: 'Deep Work.md' and 'Atomic Habits.md'.\n\nNote content:\n- [[Deep Work]] is a book by Cal Newport\n- [[Atomic Habits]] changed my morning routine\n- See also [[Focus Techniques]] and [[Reading List 2024#^morning-reads]]",
+      "expected_output": "A validation report identifying [[Focus Techniques]] as broken (no matching file) and [[Reading List 2024#^morning-reads]] as broken (note not found). [[Deep Work]] and [[Atomic Habits]] marked as valid.",
+      "expectations": [
+        "[[Deep Work]] reported as valid (✅)",
+        "[[Atomic Habits]] reported as valid (✅)",
+        "[[Focus Techniques]] reported as broken (❌)",
+        "[[Reading List 2024#^morning-reads]] reported as broken (❌)",
+        "Report includes a suggestion for fixing or investigating broken links",
+        "Broken link count is stated at the end"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create a Map of Content for Product Management topics. The vault has these notes: 'Product Strategy.md', 'User Research.md', 'Sprint Planning.md', 'OKR Framework.md', 'Stakeholder Management.md', 'Product Discovery.md'.",
+      "expected_output": "A well-structured MOC note with a title heading, notes grouped into logical sections (e.g., Strategy, Research, Execution), and each note linked using [[wikilink]] syntax with a brief description.",
+      "expectations": [
+        "Output is a complete Markdown note with a heading",
+        "All 6 notes are included as wikilinks",
+        "Notes are grouped into at least 2 logical sections",
+        "Each entry has a one-line description or label",
+        "Uses [[wikilink]] syntax consistently",
+        "Structure is readable and navigable"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I renamed 'Project Alpha' to 'Initiative Orion'. Find all wikilinks in these notes that need updating:\n- Note A contains: 'See [[Project Alpha]] for details.'\n- Note B contains: '[[Project Alpha|Alpha Budget]] was approved.'\n- Note C contains: 'Reference: [[Project Beta]] and [[Project Alpha#Timeline]].'\n\nOutput the corrected versions of all three notes.",
+      "expected_output": "All three notes with [[Project Alpha]] replaced by [[Initiative Orion]], [[Project Alpha|Alpha Budget]] replaced by [[Initiative Orion|Alpha Budget]], and [[Project Alpha#Timeline]] replaced by [[Initiative Orion#Timeline]]. Project Beta is unchanged.",
+      "expectations": [
+        "[[Project Alpha]] becomes [[Initiative Orion]] in Note A",
+        "[[Project Alpha|Alpha Budget]] becomes [[Initiative Orion|Alpha Budget]] in Note B",
+        "[[Project Alpha#Timeline]] becomes [[Initiative Orion#Timeline]] in Note C",
+        "[[Project Beta]] in Note C is not modified",
+        "All notes are output in full",
+        "No other text is changed"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Link the 'Product Strategy' note to the 'OKR Tracker' note. I want a forward link from Product Strategy to OKR Tracker and a reverse link from OKR Tracker back to Product Strategy.",
+      "expected_output": "Instructions or edits adding [[OKR Tracker]] to Product Strategy.md (in a Related or See Also section) and [[Product Strategy]] to OKR Tracker.md.",
+      "expectations": [
+        "Shows an edit to Product Strategy.md adding [[OKR Tracker]]",
+        "Shows an edit to OKR Tracker.md adding [[Product Strategy]]",
+        "Uses correct [[wikilink]] syntax in both",
+        "Suggests a section placement (Related, See Also, or at end of note)",
+        "Does not delete or overwrite existing content"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-links/evals/trigger-eval.json
+++ b/skills/obsidian-links/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-links",
+  "description": "Triggers when the user needs to create, validate, or manage wikilinks in an Obsidian vault",
+  "queries": [
+    { "id": 1, "query": "add wikilinks to this meeting note for all the people and projects mentioned", "should_trigger": true },
+    { "id": 2, "query": "find all broken links in my Obsidian vault", "should_trigger": true },
+    { "id": 3, "query": "which notes in my vault have no incoming links?", "should_trigger": true },
+    { "id": 4, "query": "convert all mentions of Deep Work to wikilinks in this note", "should_trigger": true },
+    { "id": 5, "query": "link the strategy note to the OKR tracker", "should_trigger": true },
+    { "id": 6, "query": "build a map of content for all my product management notes", "should_trigger": true },
+    { "id": 7, "query": "I renamed Project Alpha to Initiative Orion, update all wikilinks", "should_trigger": true },
+    { "id": 8, "query": "create a block reference to this paragraph in my meeting notes", "should_trigger": true },
+    { "id": 9, "query": "show me all notes that link to the Team Goals page", "should_trigger": true },
+    { "id": 10, "query": "check my Research hub for broken wikilinks", "should_trigger": true },
+    { "id": 11, "query": "summarize this YouTube video about productivity", "should_trigger": false },
+    { "id": 12, "query": "create a mermaid flowchart for the login process", "should_trigger": false },
+    { "id": 13, "query": "optimize my resume for ATS", "should_trigger": false },
+    { "id": 14, "query": "add frontmatter tags and aliases to this note", "should_trigger": false },
+    { "id": 15, "query": "create an Excalidraw whiteboard for the system design", "should_trigger": false },
+    { "id": 16, "query": "write a Python script to read JSON files", "should_trigger": false },
+    { "id": 17, "query": "what is the best note-taking system for students?", "should_trigger": false },
+    { "id": 18, "query": "transcribe this audio recording to markdown", "should_trigger": false },
+    { "id": 19, "query": "analyze the competitive landscape for my product", "should_trigger": false },
+    { "id": 20, "query": "generate a cover letter for this job application", "should_trigger": false }
+  ]
+}

--- a/skills/obsidian-markdown/README.md
+++ b/skills/obsidian-markdown/README.md
@@ -1,0 +1,79 @@
+# 📝 obsidian-markdown
+
+> Create and edit Obsidian Flavored Markdown notes with wikilinks, embeds, callouts, properties, block IDs, and all Obsidian-specific syntax extensions.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Version | 1.0.0 |
+| Author | Eric Andrade |
+| Created | 2026-04-03 |
+| Updated | 2026-04-03 |
+| Platforms | All 8 |
+| Category | Obsidian |
+| Tags | obsidian, markdown, wikilinks, callouts, frontmatter, embeds, vault |
+| Risk | Low |
+
+## Overview
+
+**obsidian-markdown** teaches agents the complete Obsidian Flavored Markdown specification — the syntax extensions Obsidian adds on top of standard Markdown. Without this skill, agents generate plain Markdown that looks correct in a text editor but breaks Obsidian's linking, graph, and embedding features.
+
+This is the **foundation skill** for all Obsidian vault work. Other skills (`obsidian-links`, `obsidian-frontmatter`, `obsidian-note-builder`) build on the syntax defined here.
+
+## Features
+
+- Complete wikilink syntax: `[[Note]]`, `[[Note|Text]]`, `[[Note#Heading]]`, `[[Note#^block-id]]`
+- Embed syntax for notes, images, PDFs, and sections: `![[embed]]`
+- Callout blocks with 14+ types, custom titles, and collapsible state
+- Frontmatter properties with YAML formatting rules
+- Inline tags and nested tag hierarchies
+- Block ID definition and linking for sub-note precision
+- Obsidian-specific formatting: `==highlight==`, LaTeX math
+- Mermaid diagram integration with vault link support
+- Markdown comments hidden in reading view: `%%comment%%`
+- Footnotes (standard and inline)
+
+## Quick Start
+
+### Triggers
+
+```bash
+# Create notes
+"Create an Obsidian note for my meeting with Sarah about Q3"
+"Write a new note about event sourcing for my Obsidian vault"
+"Make a daily note for today with proper Obsidian frontmatter"
+
+# Links and embeds
+"Add a wikilink to [[Project Alpha]] in this note"
+"Embed the risks section from [[Risk Register]] into this note"
+"Link to the specific block ^decision-001 in the decision log"
+
+# Callouts
+"Add a warning callout before this section"
+"Create a collapsible tip callout with installation steps"
+
+# Properties and tags
+"Add frontmatter to this note with tags: meeting, q3, product"
+"Set the type property to 'meeting' and add aliases"
+"Add an inline tag #project/alpha to this paragraph"
+```
+
+## Requirements
+
+No external dependencies. Works in any Obsidian vault with no plugins required.
+
+The full syntax covered by this skill is part of Obsidian core and does not require:
+- Dataview
+- Templater
+- Any community plugins
+
+## Examples
+
+| Request | What it produces |
+|---------|-----------------|
+| "Create a meeting note" | Note with frontmatter, type, tags, wikilinks to attendees, task items |
+| "Embed the summary section from another note" | `![[Other Note#Summary]]` embed block |
+| "Add a warning callout" | `> [!warning]` block with title and content |
+| "Make this paragraph linkable from other notes" | Paragraph with `^block-id` appended |
+| "Link to the decisions heading in [[Decision Log]]" | `[[Decision Log#Decisions]]` wikilink |

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,0 +1,337 @@
+---
+name: obsidian-markdown
+description: This skill should be used when the user is working with Obsidian notes and needs to create or edit files using Obsidian Flavored Markdown syntax. Use when the user mentions wikilinks, callouts, embeds, frontmatter properties, tags, block references, or any Obsidian-specific syntax that extends standard Markdown.
+license: MIT
+---
+
+## Purpose
+
+This skill teaches agents the complete Obsidian Flavored Markdown specification — the set of syntax extensions that Obsidian adds on top of standard CommonMark and GitHub Flavored Markdown. These extensions are not valid in plain Markdown editors and must be written correctly to work in Obsidian.
+
+Standard Markdown knowledge is assumed. This skill covers only the Obsidian-specific additions: wikilinks, embeds, callouts, properties (frontmatter), block IDs, comments, and Obsidian-specific formatting. Agents that generate Markdown without this skill will produce notes that look correct in a plain editor but break Obsidian's linking, embedding, and graph features.
+
+This skill is the **foundation** of all Obsidian-related work in this repository. Other skills such as `obsidian-links`, `obsidian-frontmatter`, and `obsidian-note-builder` build on top of the syntax defined here.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user asks to create a new note in Obsidian
+- The user wants to add links between notes using the `[[wikilink]]` format
+- The user needs to embed content from another note, image, or PDF
+- The user wants to add callouts (highlighted info blocks) to a note
+- The user needs to set frontmatter properties (tags, aliases, cssclasses, custom fields)
+- The user wants to link to a specific heading or block within a note
+- The user asks to create a note that "links to" or "is linked from" another note
+- The agent is generating or editing any `.md` file that will live inside an Obsidian vault
+- The user mentions Obsidian-specific features: graph view, backlinks, MOC, Zettelkasten, daily notes
+
+Do NOT use this skill when:
+
+- The user is generating Markdown for GitHub, a blog, or any non-Obsidian context
+- The user needs to validate that existing links point to real notes — use `obsidian-links` instead
+- The user needs to standardize frontmatter formatting and naming — use `obsidian-frontmatter` instead
+
+## Workflow
+
+### Step 1: Identify the Note Type and Required Syntax
+
+Before writing, identify what kind of note the user needs:
+
+| Note type | Syntax features likely needed |
+|-----------|-------------------------------|
+| Meeting note | Frontmatter, wikilinks to people/projects, tasks |
+| Daily note | Frontmatter, embeds, inline tags |
+| MOC (Map of Content) | Wikilinks, headings, embedded notes |
+| Atomic concept note | Frontmatter, block IDs, wikilinks |
+| Reference/resource note | Frontmatter with source, tags, wikilinks |
+| Canvas-linked note | Frontmatter, block IDs for precise embeds |
+
+### Step 2: Write the Frontmatter (Properties)
+
+Always place a YAML frontmatter block at the very top of the file, before any other content:
+
+```yaml
+---
+title: My Note
+date: 2024-01-15
+tags:
+  - project
+  - active
+aliases:
+  - Alternative Title
+cssclasses:
+  - custom-class
+---
+```
+
+Frontmatter rules:
+- The `---` delimiters must be the very first and last characters of the block with no blank lines before the opening `---`
+- `tags` must be a YAML list (one tag per line with `- ` prefix) — never use inline format `[tag1, tag2]`
+- `aliases` defines alternative note names for Obsidian's link suggestion system
+- `cssclasses` applies custom CSS classes to the note in reading view
+- Custom properties (e.g., `status: active`) are valid and appear in the Properties panel
+
+### Step 3: Write Internal Links (Wikilinks)
+
+Use wikilinks for all internal vault connections:
+
+```markdown
+[[Note Name]]                          Link to note by name
+[[Note Name|Display Text]]             Custom display text
+[[Note Name#Heading]]                  Link to a specific heading
+[[Note Name#^block-id]]                Link to a specific block
+[[#Heading in same note]]              Link to heading in the current note
+```
+
+Key rules:
+- Use `[[wikilinks]]` for internal notes — Obsidian tracks renames automatically
+- Use standard `[text](url)` Markdown links for all external URLs
+- Never use wikilinks for external URLs
+- Link text is optional — `[[Note]]` displays the note name as the link text
+
+### Step 4: Embed Content
+
+Prefix any wikilink with `!` to embed its content inline:
+
+```markdown
+![[Note Name]]                        Embed the full note
+![[Note Name#Heading]]                Embed only a section of a note
+![[Note Name#^block-id]]              Embed a specific block
+![[image.png]]                        Embed an image
+![[image.png|300]]                    Embed an image with fixed width (pixels)
+![[document.pdf]]                     Embed a PDF
+![[document.pdf#page=3]]              Embed a specific PDF page
+```
+
+### Step 5: Add Callouts
+
+Callouts are highlighted info blocks built on top of Markdown blockquotes:
+
+```markdown
+> [!note]
+> This is a standard note callout.
+
+> [!warning] Custom Title
+> Callout with a custom title overriding the type name.
+
+> [!tip]+ Expanded by default
+> The + makes this callout expanded. Use - to make it collapsed by default.
+
+> [!faq]- Collapsed by default
+> This callout starts collapsed. Click the title to expand.
+```
+
+Common callout types: `note`, `tip`, `warning`, `info`, `example`, `quote`, `bug`, `danger`, `success`, `failure`, `question`, `abstract`, `todo`.
+
+Callouts can be nested:
+```markdown
+> [!info]
+> Outer callout.
+> > [!warning]
+> > Nested callout inside the outer one.
+```
+
+### Step 6: Define and Link Blocks
+
+A block is any paragraph, list item, heading, or code block. Add a unique block ID to make it linkable:
+
+```markdown
+This paragraph can be embedded or linked to from anywhere in the vault.
+^my-block-id
+```
+
+For lists and blockquotes, place the ID on the line immediately following the block:
+
+```markdown
+> A quoted passage that needs to be linkable.
+
+^quote-block-id
+```
+
+Block IDs must contain only letters, numbers, and hyphens. They must be unique within the vault.
+
+### Step 7: Add Tags and Comments
+
+Inline tags can appear anywhere in the body of a note:
+
+```markdown
+#tag                           Inline tag
+#nested/tag                    Nested tag hierarchy
+#project/alpha/milestone-1     Deep nesting is supported
+```
+
+Tag naming rules: tags may contain letters, numbers, underscores, hyphens, and forward slashes. They must not start with a number. Tags defined in frontmatter and inline tags both appear in Obsidian's tag panel.
+
+Comments are completely hidden in reading view:
+
+```markdown
+This text is visible. %%This comment is hidden in reading view.%%
+
+%%
+This entire multi-line block
+is hidden in reading view.
+%%
+```
+
+### Step 8: Apply Obsidian-Specific Formatting
+
+Highlight syntax (not standard Markdown):
+
+```markdown
+==Highlighted text==
+```
+
+Math blocks (LaTeX, rendered by MathJax):
+
+```markdown
+Inline: $e^{i\pi} + 1 = 0$
+
+Block:
+$$
+\frac{a}{b} = c
+$$
+```
+
+Diagrams (Mermaid, rendered natively in Obsidian):
+
+````markdown
+```mermaid
+graph TD
+    A[Start] --> B{Decision}
+    B -->|Yes| C[Action]
+    B -->|No| D[Skip]
+```
+````
+
+To link Mermaid node IDs to vault notes, append: `class NodeName internal-link;`
+
+Footnotes:
+
+```markdown
+Text with a footnote[^1].
+
+[^1]: Footnote content here.
+
+Inline footnote^[This footnote is defined inline].
+```
+
+## Critical Rules
+
+**NEVER:**
+- Mix wikilinks and markdown links in the same context — wikilinks for internal notes, markdown links for external URLs only
+- Use inline tag format in frontmatter YAML: `tags: [tag1, tag2]` — always use the list format with dashes
+- Add a space before the opening `---` of frontmatter — it must be the absolute first line of the file
+- Invent wikilink targets that may not exist in the vault — use `obsidian-links` to validate targets
+- Use `[[wikilinks]]` to link to external URLs — they will not work as expected
+- Place block IDs immediately before a blank line — the ID must follow the block on the next line without any gap
+
+**ALWAYS:**
+- Use `[[wikilinks]]` for all internal vault note references
+- Place frontmatter at the very top of the file — no content before the opening `---`
+- Use YAML list format for all multi-value properties: `tags`, `aliases`, `cssclasses`
+- Test that wikilink targets exist using `obsidian-links` when creating notes with links
+- Use `==highlight==` for Obsidian-specific highlights — the `<mark>` HTML tag also works but is less portable
+- Ensure block IDs are unique within the note — duplicates cause linking to fail silently
+
+## Example Usage
+
+### Example 1: Create a meeting note
+
+```
+User: Create a meeting note for my call with Sarah about the Q3 roadmap
+```
+
+Output:
+
+```markdown
+---
+date: 2026-04-03
+type: meeting
+tags:
+  - meeting
+  - q3
+  - roadmap
+attendees:
+  - "[[Sarah Johnson]]"
+status: inbox
+---
+
+# Meeting with Sarah — Q3 Roadmap
+
+## Context
+
+> [!info] Related
+> See [[Q3 Roadmap MOC]] and [[Sarah Johnson]] for background.
+
+## Key Points
+
+- Discussed scope for Q3 delivery milestones
+- Alignment needed on [[Product Strategy 2026]]
+- Sarah raised concerns about timeline for [[Feature Alpha]]
+
+## Action Items
+
+- [ ] Share updated roadmap draft — due [[2026-04-07]]
+- [ ] Schedule follow-up with engineering
+
+## Open Questions
+
+- What is the budget approved for Q3?
+
+^meeting-sarah-q3-2026
+```
+
+---
+
+### Example 2: Add a callout with an embedded section
+
+```
+User: Add a warning callout to this note and embed the risks section from another note
+```
+
+Output:
+
+```markdown
+> [!warning] Review Before Proceeding
+> This section depends on decisions logged in [[Decision Log#Architecture Choices]].
+
+![[Risk Register#Current Risks]]
+```
+
+---
+
+### Example 3: Create a note with block IDs for precise linking
+
+```
+User: Write a note about event sourcing that other notes can link to specific sections
+```
+
+Output:
+
+```markdown
+---
+tags:
+  - architecture
+  - event-sourcing
+aliases:
+  - Event Sourcing Pattern
+---
+
+# Event Sourcing
+
+Event sourcing captures all state changes as a sequence of immutable events.
+^event-sourcing-definition
+
+## When to Use
+
+Apply event sourcing when the audit trail of state changes is as important as the current state.
+^event-sourcing-when-to-use
+
+## Trade-offs
+
+Higher complexity in query patterns; enables full replay and temporal queries.
+^event-sourcing-tradeoffs
+```
+
+Other notes can now embed `![[Event Sourcing#^event-sourcing-definition]]` to pull exactly the definition paragraph.

--- a/skills/obsidian-markdown/evals/evals.json
+++ b/skills/obsidian-markdown/evals/evals.json
@@ -1,0 +1,63 @@
+{
+  "skill_name": "obsidian-markdown",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create an Obsidian meeting note for a call with Sarah about the Q3 roadmap. Include proper frontmatter, wikilinks to Sarah and the Q3 Roadmap MOC, a callout for context, and task items.",
+      "expected_output": "A complete Obsidian note with YAML frontmatter, wikilinks, a callout block, and task checkboxes",
+      "expectations": [
+        "Output contains valid YAML frontmatter between --- delimiters at the top of the file",
+        "Output uses [[wikilink]] format for internal references (Sarah, Q3 Roadmap MOC)",
+        "Output includes at least one callout block using > [!type] syntax",
+        "Output includes task items using - [ ] format",
+        "Output uses tags as a YAML list with dashes, not inline format"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Write a note about event sourcing that other notes can link to specific paragraphs. Include block IDs for the definition, when-to-use, and trade-offs sections.",
+      "expected_output": "A structured note with block IDs appended after each target paragraph",
+      "expectations": [
+        "Output contains frontmatter with relevant tags",
+        "Output appends ^block-id after each target paragraph on its own line",
+        "Output has at least three block IDs for the three specified sections",
+        "Block IDs use only letters, numbers, and hyphens",
+        "Output demonstrates correct block ID placement without blank lines between paragraph and ID"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Add an embed of the Current Risks section from [[Risk Register]] and a collapsed warning callout before it.",
+      "expected_output": "A warning callout followed by an embed of a specific note section",
+      "expectations": [
+        "Output uses > [!warning]- syntax for a collapsed callout",
+        "Output uses ![[Risk Register#Current Risks]] for the section embed",
+        "Output places the callout before the embed as requested",
+        "Embed syntax uses the correct ![[Note#Heading]] format"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Create a daily note for today with frontmatter (date, tags: daily), an inline tag #review, a highlight using ==text==, and a footnote.",
+      "expected_output": "A daily note demonstrating all four Obsidian-specific syntax elements",
+      "expectations": [
+        "Output contains frontmatter with date and tags fields",
+        "Output contains at least one inline #tag in the body",
+        "Output contains ==highlighted text== using Obsidian highlight syntax",
+        "Output contains a footnote using [^1] syntax",
+        "Frontmatter tags use YAML list format, not inline"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Write a note that embeds a full sub-note, an image with a 400px width, and a specific page of a PDF document.",
+      "expected_output": "A note demonstrating three different embed types with correct syntax",
+      "expectations": [
+        "Output uses ![[Note Name]] for full note embed",
+        "Output uses ![[image.png|400]] for sized image embed",
+        "Output uses ![[document.pdf#page=3]] for PDF page embed",
+        "All embeds are prefixed with ! before the [[ syntax"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-markdown/evals/trigger-eval.json
+++ b/skills/obsidian-markdown/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-markdown",
+  "description": "Triggers for creating and editing Obsidian Flavored Markdown notes with vault-specific syntax",
+  "queries": [
+    {"id": 1, "query": "Create an Obsidian note for my meeting with Sarah about the Q3 roadmap", "should_trigger": true},
+    {"id": 2, "query": "Write a new note about event sourcing for my Obsidian vault with wikilinks", "should_trigger": true},
+    {"id": 3, "query": "Add a warning callout to this section of my Obsidian note", "should_trigger": true},
+    {"id": 4, "query": "Embed the risks section from [[Risk Register]] into this note", "should_trigger": true},
+    {"id": 5, "query": "Make a daily note for today with proper Obsidian frontmatter and tags", "should_trigger": true},
+    {"id": 6, "query": "Add wikilinks to people and projects mentioned in this meeting note", "should_trigger": true},
+    {"id": 7, "query": "Create a Zettelkasten atomic note about systems thinking with block IDs", "should_trigger": true},
+    {"id": 8, "query": "Add a collapsible tip callout with installation instructions to this note", "should_trigger": true},
+    {"id": 9, "query": "Set frontmatter properties on this note: type meeting, tags project and q3", "should_trigger": true},
+    {"id": 10, "query": "Write a note that links to a specific heading in my Architecture Decisions file", "should_trigger": true},
+    {"id": 11, "query": "Create a GitHub README.md for my open source project", "should_trigger": false},
+    {"id": 12, "query": "Write a blog post in Markdown for my personal website", "should_trigger": false},
+    {"id": 13, "query": "Fix the broken wikilinks in my vault notes", "should_trigger": false},
+    {"id": 14, "query": "Standardize the frontmatter across all my vault notes", "should_trigger": false},
+    {"id": 15, "query": "Summarize this YouTube video", "should_trigger": false},
+    {"id": 16, "query": "Convert this PDF to Markdown", "should_trigger": false},
+    {"id": 17, "query": "Create a Mermaid diagram of the CI/CD pipeline", "should_trigger": false},
+    {"id": 18, "query": "Write a Python script to process text files", "should_trigger": false},
+    {"id": 19, "query": "Format my resume as a Markdown document for LinkedIn", "should_trigger": false},
+    {"id": 20, "query": "Generate a CHANGELOG.md file for my GitHub repository", "should_trigger": false}
+  ]
+}

--- a/skills/obsidian-note-builder/README.md
+++ b/skills/obsidian-note-builder/README.md
@@ -1,0 +1,67 @@
+# 🏗️ obsidian-note-builder
+
+> Build complete, knowledge-graph-ready Obsidian notes from raw content. Extracts entities, inserts wikilinks, applies the right note template, and integrates with your vault's structure.
+
+## Metadata
+
+| Field     | Value                                              |
+|-----------|----------------------------------------------------|
+| Version   | 1.0.0                                              |
+| Author    | Eric Andrade                                       |
+| Created   | 2026-04-03                                         |
+| Updated   | 2026-04-03                                         |
+| Platforms | All 8                                              |
+| Category  | Obsidian / Knowledge Management                    |
+| Tags      | obsidian, note-building, zettelkasten, knowledge-graph, entity-extraction |
+| Risk      | Low                                                |
+
+## Overview
+
+`obsidian-note-builder` creates complete Obsidian notes from raw input (brain dumps, meeting summaries, book highlights, article excerpts). It analyzes content to extract entities, converts them to wikilinks, selects and applies the correct note template, and structures the result so it integrates immediately into the vault's knowledge graph.
+
+## Features
+
+- **Entity extraction** — Identifies people, projects, concepts, tools, and documents to link
+- **Auto-wikilinks** — Converts extracted entities to `[[wikilinks]]` on first mention
+- **Note type selection** — Atomic concept, meeting note, reference, project note
+- **Zettelkasten atomicity** — Splits multi-concept input into separate atomic notes
+- **Template application** — Applies the right frontmatter and body structure per note type
+- **Graph integration** — Identifies which existing notes should link back to the new note
+- **Follow-up suggestions** — Lists new notes to create for referenced-but-missing entities
+
+## Quick Start / Triggers
+
+This skill activates when you use phrases like:
+
+- "Turn this brain dump into an Obsidian note"
+- "Create a meeting note for today's session"
+- "Build a reference note for this book"
+- "Add this to my vault as a concept note"
+- "Extract entities and create notes"
+- "Import this article into my vault"
+- "Split this large note into atomic notes"
+
+## Note Types
+
+| Type | Best For |
+|------|---------|
+| Atomic Concept | One clear idea — Zettelkasten style |
+| Meeting Note | Structured meeting with attendees, decisions, actions |
+| Reference Note | Book, article, resource with key takeaways |
+| Project Note | Project overview with status, stakeholders, actions |
+
+## Requirements
+
+- An Obsidian vault (for entity lookup and tag convention detection)
+- No special plugins required for note creation
+- Optional: Dataview plugin for querying the notes afterward
+
+## Examples
+
+| Input | Output |
+|-------|--------|
+| Brain dump about a concept | Atomic note with frontmatter, entities linked, related notes section |
+| Meeting transcript | Meeting note with attendees, decisions, actions, wikilinks |
+| Book highlights | Reference note with key takeaways, author linked, concepts flagged |
+| Project description | Project note with status, stakeholders, next actions |
+| Large sprawling note | Split into atomic notes + parent MOC linking them all |

--- a/skills/obsidian-note-builder/SKILL.md
+++ b/skills/obsidian-note-builder/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: obsidian-note-builder
+description: This skill should be used when the user wants to create a well-structured, richly linked Obsidian note from raw content, ideas, or instructions. Use when the user needs entity extraction, automatic wikilink insertion, Zettelkasten-style atomic note formatting, or building a note that integrates seamlessly into an existing vault's knowledge graph.
+license: MIT
+---
+
+## Purpose
+
+This skill builds complete, knowledge-graph-ready Obsidian notes. It does more than just format text — it analyzes content to extract entities (people, projects, concepts, tools), converts those entities to wikilinks, chooses the right note type (atomic concept, project note, meeting note, daily note, reference note), and structures the output so it integrates with an existing vault's linking and tagging conventions.
+
+The result is a note that is immediately navigable in Obsidian, discoverable through search and Dataview, and connected to the knowledge graph via bidirectional links.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user provides raw notes, a transcript, or a brain dump and asks to "turn it into a proper Obsidian note"
+- The user wants a new note created that will link to and be linked from existing notes
+- The user asks to "extract entities" from a piece of text and auto-link them
+- The user wants Zettelkasten-style atomic notes where each note expresses one idea
+- The user provides a meeting summary and wants a structured meeting note
+- The user wants a reference note for a book, article, or resource they consumed
+- The user needs to import external content (web article, PDF excerpt, email) into their vault
+- The user says "build a note", "create a note in Obsidian", or "add this to my vault"
+
+Do NOT use this skill when:
+
+- The user only wants to update or fix the frontmatter properties — use `obsidian-frontmatter` instead
+- The user only wants to add wikilinks to an existing note — use `obsidian-links` instead
+- The user wants to automate bulk note creation — use `obsidian-automation` instead
+- The user explicitly says they want plain Markdown without Obsidian-specific features
+
+## Note Types and Templates
+
+### Atomic Concept Note (Zettelkasten)
+
+An atomic note captures exactly one idea. It is self-contained, evergreen, and heavily linked:
+
+```
+---
+title: <Concept Name>
+date: YYYY-MM-DD
+tags:
+  - concept
+  - <topic>
+aliases:
+  - <alternative name>
+---
+
+# <Concept Name>
+
+<One to three paragraph clear definition of the concept.>
+
+## Key Principles
+
+- <Principle 1>
+- <Principle 2>
+
+## Related Concepts
+
+- [[Related Concept A]] — brief relationship description
+- [[Related Concept B]] — brief relationship description
+
+## Sources
+
+- [[Book or Article Title]] by Author Name
+```
+
+### Meeting Note
+
+```
+---
+title: <Meeting Title — Date>
+date: YYYY-MM-DD
+tags:
+  - meeting
+attendees:
+  - "[[Person One]]"
+  - "[[Person Two]]"
+project: "[[Project Name]]"
+status: done
+---
+
+# <Meeting Title>
+
+**Date:** [[YYYY-MM-DD]]  
+**Attendees:** [[Person One]], [[Person Two]]
+
+## Agenda
+
+1. Topic One
+2. Topic Two
+
+## Notes
+
+<Structured notes by agenda item>
+
+## Decisions
+
+- <Decision 1>
+
+## Action Items
+
+- [ ] <Task> — assigned to [[Person]]
+
+## Next Meeting
+
+[[Next Meeting Note]] scheduled for <date>
+```
+
+### Reference / Resource Note
+
+```
+---
+title: <Resource Title>
+date: YYYY-MM-DD
+tags:
+  - reference
+  - <topic>
+source: "<URL or citation>"
+author: <Author Name>
+read_date: YYYY-MM-DD
+rating: <1-5>
+---
+
+# <Resource Title>
+
+> <One-line summary of the resource's main argument or value>
+
+## Key Takeaways
+
+- <Takeaway 1>
+- <Takeaway 2>
+
+## Quotes
+
+> "<Memorable quote>" — <Author>
+
+## How It Connects
+
+- Relevant to [[Project X]] because...
+- Supports the ideas in [[Concept Y]]
+```
+
+### Project Note
+
+```
+---
+title: <Project Name>
+date: YYYY-MM-DD
+status: active
+priority: medium
+tags:
+  - project
+stakeholders:
+  - "[[Person]]"
+due_date: YYYY-MM-DD
+---
+
+# <Project Name>
+
+> <One-sentence project description>
+
+## Goal
+
+<What success looks like>
+
+## Status
+
+<Current state of the project>
+
+## Key Decisions
+
+- <Decision with [[Meeting Note]] link>
+
+## Resources
+
+- [[Related Document]]
+- [[Team Member]]
+
+## Next Actions
+
+- [ ] <Task>
+```
+
+## Workflow
+
+### Step 0: Discover Existing Vault Context
+
+Before building the note, understand the vault:
+
+1. Ask the user: "What is the vault root path?" (if not already known)
+2. Scan for naming conventions — is the vault flat or folder-based?
+3. Identify existing related notes that the new note should link to:
+   ```bash
+   find <vault-root> -name "*.md" | xargs grep -l "<key terms>" 2>/dev/null | head 10
+   ```
+4. Look for an existing tag taxonomy by scanning frontmatter in similar notes:
+   ```bash
+   grep -rh "^  - " <vault-root>/**/*.md | sort | uniq -c | sort -rn | head 20
+   ```
+5. If discovery is not possible (no vault path), proceed with generic conventions and note the assumptions made
+
+### Step 1: Classify the Input
+
+Read the user's input and determine:
+
+- **Raw content or brain dump** → Extract, structure, atomize
+- **Meeting transcript or summary** → Meeting note template
+- **Book/article highlights** → Reference note template
+- **Project description** → Project note template
+- **Technical concept or idea** → Atomic concept note
+- **Daily journal entry** → Daily note format
+
+If ambiguous, ask: "What type of note should this be — a concept note, meeting note, reference note, or project note?"
+
+### Step 2: Extract Entities
+
+Scan the input text for entities that should become wikilinks:
+
+**Entity categories to extract:**
+- **People**: Full names, nicknames matching known vault notes
+- **Projects**: Named initiatives, products, code names
+- **Concepts**: Technical terms, frameworks, methodologies with their own notes
+- **Places**: Locations significant to the vault's domain
+- **Tools / Systems**: Software, hardware, platforms with their own notes
+- **Documents**: Reports, articles, books referenced
+
+**Entity extraction rules:**
+- Only link entities that are likely to have (or should have) a corresponding note
+- Generic words ("meeting", "project", "task") are not entities
+- The same entity should only be linked on first mention per section
+- If an entity does not have an existing note, mark it as a candidate for creation: `[[New Concept]] ⟵ create this note`
+
+### Step 3: Structure the Note
+
+Apply the appropriate template from the note types above. Then:
+
+1. **Write a clear, specific title** — descriptive, unique, suitable as a filename
+2. **Build the frontmatter block** — using the `obsidian-frontmatter` conventions (multiline lists, ISO dates, quoted wikilinks)
+3. **Write the note body** — including all extracted entities as wikilinks
+4. **Add a Related / See Also section** — link to conceptually adjacent notes
+5. **Add a Sources section** if the note synthesizes external content
+
+### Step 4: Apply Zettelkasten Atomicity (If Concept Note)
+
+For atomic concept notes:
+
+- Each note should express **one idea** clearly
+- If the input covers multiple ideas, split into multiple notes and link them
+- The opening paragraph must work as a standalone definition (no "as mentioned above")
+- Prefer active, declarative sentences: "Atomic notes are single-idea notes" not "This is a note about..."
+- The note should not repeat content that lives in another linked note — summarize and link instead
+
+### Step 5: Output the Complete Note
+
+Output the full Markdown content of the note including frontmatter. After the note, list:
+
+1. **New notes to create** — entities referenced but not yet in the vault
+2. **Existing notes to update** — notes that should now link back to this new note
+3. **Tag corrections** — any tags that don't match the vault's detected taxonomy
+
+## Entity Linking Rules
+
+- Link on the first meaningful mention per section, not every occurrence
+- Use display text when the linked note name differs from the natural phrasing:
+  - `[[Product Discovery|discovery process]]`
+  - `[[Alice Chen|Alice]]`
+- Never link common words that happen to match a note name unless the semantic connection is intentional
+- When the user mentions a concept that exists in the vault both as a tag and as a note, prefer the wikilink
+
+## Critical Rules
+
+**NEVER:**
+- Create a note without a frontmatter block
+- Link to a note that does not exist without flagging it as a "note to create"
+- Duplicate content that already lives in another note — link instead
+- Use heading levels inconsistently (always `#` for title, `##` for sections, `###` for subsections)
+- Add external URLs as wikilinks — use standard Markdown link syntax for external URLs
+- Output a partial note — always output the complete note
+
+**ALWAYS:**
+- Match the vault's existing tag naming convention when detectable
+- Put the opening `---` on line 1 with no blank line before it
+- Include at least one wikilink in every note (it should connect to the graph)
+- Suggest follow-up notes to create when entities are referenced but not yet in the vault
+- Use a title that works as an Obsidian filename (no `/`, `?`, `#`, `^`, `[`, `]`, `|` characters)
+- End the note with a `## See Also` or `## Related` section
+
+## Example Usage
+
+**Example 1: Convert a brain dump into an atomic concept note**
+
+User: "Turn this into a proper Obsidian note: 'Evergreen notes are notes designed to accumulate insight over time. Unlike fleeting notes, they are written to stand alone. Key principle from Andy Matuschak.'"
+
+Output:
+```markdown
+---
+title: Evergreen Notes
+date: 2024-01-15
+tags:
+  - concept
+  - note-taking
+aliases:
+  - Evergreen Note
+---
+
+# Evergreen Notes
+
+Evergreen notes are permanent notes designed to accumulate insight over time. Unlike fleeting notes captured in the moment, evergreen notes are written with enough context to stand alone and remain useful long after the writing session.
+
+## Key Principles
+
+- Write for your future self, not just for now
+- Each note captures one idea fully and clearly
+- Notes are revised and updated as understanding deepens
+
+## Origin
+
+Coined by [[Andy Matuschak]] as part of his writing practice.
+
+## Related Concepts
+
+- [[Atomic Notes]] — evergreen notes are always atomic
+- [[Fleeting Notes]] — the raw capture stage before evergreen refinement
+- [[Zettelkasten]] — the system that popularized this practice
+
+## See Also
+
+- [[Note-Taking Workflow]]
+```
+
+---
+
+**Example 2: Structure a meeting summary**
+
+User: "Create a meeting note for today's Q2 Planning session. Alice Chen and Bob Martinez attended. We decided to push the launch date to March 15. Bob owns the announcement. Next meeting in two weeks."
+
+Output: Complete meeting note with frontmatter, structured agenda/notes/decisions/actions, wikilinks for Alice Chen, Bob Martinez, and the action item, plus a flag to create `[[Q2 Planning — 2024-02-15]]` for the next meeting.
+
+---
+
+**Example 3: Build a reference note from book highlights**
+
+User: "Create a reference note for the book 'Building a Second Brain' by Tiago Forte. Key ideas: CODE method (Capture, Organize, Distill, Express), progressive summarization, project vs area vs resource vs archive (PARA)."
+
+Output: A reference note with frontmatter (title, author, tags), key takeaways as bullets, the CODE and PARA acronyms explained, and wikilinks to `[[Progressive Summarization]]`, `[[PARA Method]]`, etc. as candidates for future atomic notes.
+
+---
+
+**Example 4: Import web article content into vault**
+
+User: "Add this article summary to my vault as a reference note: [article excerpt provided]"
+
+1. Extract key information (author, source URL, publication date)
+2. Identify main concepts discussed
+3. Create reference note with source frontmatter
+4. Extract entities for wikilinks
+5. Output complete note + list of concept notes to create
+
+---
+
+**Example 5: Split a large note into atomic notes**
+
+User: "This note has become too big. Split it into separate atomic notes, one per concept."
+
+1. Read the note and identify concept boundaries
+2. Write a separate atomic note for each concept
+3. Replace the original note with a MOC that links to all child notes
+4. Output all new notes + the updated parent note

--- a/skills/obsidian-note-builder/evals/evals.json
+++ b/skills/obsidian-note-builder/evals/evals.json
@@ -1,0 +1,72 @@
+{
+  "skill_name": "obsidian-note-builder",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Convert this brain dump into a proper Zettelkasten atomic note for my Obsidian vault:\n\n'Systems thinking is a way of seeing the world as interconnected wholes rather than separate parts. Key concept: feedback loops. Two types: reinforcing loops (amplify change) and balancing loops (resist change). Related to complexity theory and emergence. Term popularized by Peter Senge in The Fifth Discipline.'",
+      "expected_output": "A complete Obsidian note with frontmatter (title, date, tags: concept, aliases), a clear one-paragraph definition, Key Principles section with bullet points, a Related Concepts section with wikilinks to Feedback Loops, Reinforcing Loops, Balancing Loops, Complexity Theory, Emergence, and Peter Senge, and a Sources section linking to The Fifth Discipline.",
+      "expectations": [
+        "Note starts with a YAML frontmatter block on line 1",
+        "tags include concept and a domain tag",
+        "Opening paragraph provides a standalone definition of systems thinking",
+        "Related Concepts section includes wikilinks to at least 3 related terms",
+        "Peter Senge is linked as a wikilink",
+        "The Fifth Discipline is referenced in a Sources section",
+        "Note is self-contained and expresses exactly one concept"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Build a complete meeting note from this summary:\n\nDate: March 15, 2024\nMeeting: Q2 Product Strategy Review\nAttendees: Sarah Kim (PM), James Torres (Engineering), Priya Patel (Design)\nDecisions: Move launch from April to May 1. Prioritize mobile over web for v1.\nAction items: Sarah to update the roadmap by March 20. James to revise sprint plan. Priya to finalize designs for mobile flow.\nNext meeting: March 22.",
+      "expected_output": "A complete meeting note with frontmatter (title, date: 2024-03-15, attendees as quoted wikilinks, tags: meeting, status: done), structured body with Agenda/Notes/Decisions/Action Items sections, checkboxes for action items with wikilink assignments, and a link to a next meeting note.",
+      "expectations": [
+        "Frontmatter has date: 2024-03-15",
+        "attendees lists Sarah Kim, James Torres, Priya Patel as quoted wikilinks",
+        "tags includes meeting",
+        "Decisions section contains both decisions clearly stated",
+        "Action Items section uses - [ ] checkbox format",
+        "Each action item links to the assigned person with [[wikilink]]",
+        "A next meeting reference is included"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create a reference note for the book 'Thinking Fast and Slow' by Daniel Kahneman. Key ideas: System 1 (fast, automatic, emotional, intuitive) vs System 2 (slow, deliberate, logical). Anchoring bias, availability heuristic, loss aversion. I read it in February 2024 and rate it 5/5.",
+      "expected_output": "A reference note with frontmatter (title, author, read_date: 2024-02-01 or similar, rating: 5, tags: reference, books), a one-line summary, Key Takeaways section covering System 1/2 and the biases, wikilinks to System 1, System 2, Anchoring Bias, Availability Heuristic, Loss Aversion as candidate notes, and a How It Connects section.",
+      "expectations": [
+        "Frontmatter includes author: Daniel Kahneman",
+        "read_date is in ISO 8601 format (2024-02-XX)",
+        "rating is 5 (numeric)",
+        "tags includes reference and books or similar",
+        "Key Takeaways explains System 1 vs System 2",
+        "Anchoring bias, availability heuristic, and loss aversion mentioned as wikilinks",
+        "At least one How It Connects or Related entry"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "This note has gotten too broad. Split it into separate atomic notes:\n\n# Productivity Concepts\n\nPomodoro Technique: Work in 25-minute focused blocks, take 5-minute breaks. After 4 pomodoros, take a longer break. Created by Francesco Cirillo.\n\nDeep Work: Cal Newport's concept. Work with full concentration on cognitively demanding tasks without distraction. Contrasted with shallow work.\n\nZero Inbox: Email management philosophy. Process every email to completion during each session. Archive or delete everything.",
+      "expected_output": "Three separate atomic notes (Pomodoro Technique, Deep Work, Zero Inbox) each with their own frontmatter and body, plus a parent MOC note that links to all three.",
+      "expectations": [
+        "Three complete separate notes are output",
+        "Each note has its own frontmatter with name, date, tags",
+        "Pomodoro Technique links to [[Francesco Cirillo]]",
+        "Deep Work links to [[Cal Newport]] and [[Shallow Work]]",
+        "All notes have a Related Concepts section",
+        "A parent MOC note is output linking to all three atomic notes"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Import this article excerpt into my vault as a reference note. Extract main entities and flag new notes to create:\n\n'According to a 2023 McKinsey report, organizations that use generative AI for product development see a 40% reduction in time-to-market. The key enablers are: design thinking workshops, rapid prototyping, and cross-functional teams including product managers, engineers, and UX researchers.'",
+      "expected_output": "A reference note with source (McKinsey report), key statistics, entities extracted (McKinsey, generative AI, design thinking, rapid prototyping, cross-functional teams), and a list of notes to create for un-linked concepts.",
+      "expectations": [
+        "Frontmatter includes source reference to McKinsey",
+        "Key finding (40% reduction) is captured",
+        "At least 3 entities extracted and linked",
+        "An After This section or similar lists notes to create",
+        "Note is structured as a reference, not a concept note"
+      ]
+    }
+  ]
+}

--- a/skills/obsidian-note-builder/evals/trigger-eval.json
+++ b/skills/obsidian-note-builder/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "obsidian-note-builder",
+  "description": "Triggers when the user wants to create a structured, wikilinked Obsidian note from raw content or ideas",
+  "queries": [
+    { "id": 1, "query": "turn this brain dump into a proper Obsidian concept note", "should_trigger": true },
+    { "id": 2, "query": "create a meeting note from today's Q2 planning session summary", "should_trigger": true },
+    { "id": 3, "query": "build a reference note for the book Thinking Fast and Slow", "should_trigger": true },
+    { "id": 4, "query": "extract entities from this text and add wikilinks to create an Obsidian note", "should_trigger": true },
+    { "id": 5, "query": "add this article to my vault as a structured note", "should_trigger": true },
+    { "id": 6, "query": "this note is too long, split it into atomic Zettelkasten notes", "should_trigger": true },
+    { "id": 7, "query": "create an Obsidian project note for Initiative Orion", "should_trigger": true },
+    { "id": 8, "query": "build a well-structured note about systems thinking for my vault", "should_trigger": true },
+    { "id": 9, "query": "import this email into my Obsidian vault as a reference note", "should_trigger": true },
+    { "id": 10, "query": "create a note about the new team member and link it to relevant project notes", "should_trigger": true },
+    { "id": 11, "query": "add frontmatter tags to my existing note", "should_trigger": false },
+    { "id": 12, "query": "find broken wikilinks in my vault", "should_trigger": false },
+    { "id": 13, "query": "draw a flowchart for the user registration process", "should_trigger": false },
+    { "id": 14, "query": "optimize my resume for a software engineering role", "should_trigger": false },
+    { "id": 15, "query": "create a bash script to archive old Obsidian notes", "should_trigger": false },
+    { "id": 16, "query": "summarize this YouTube video", "should_trigger": false },
+    { "id": 17, "query": "create an Excalidraw diagram for the system architecture", "should_trigger": false },
+    { "id": 18, "query": "transcribe this audio file to Markdown", "should_trigger": false },
+    { "id": 19, "query": "what is the best PKM system for academics?", "should_trigger": false },
+    { "id": 20, "query": "write a Python script to read and process a CSV file", "should_trigger": false }
+  ]
+}

--- a/skills/webpage-reader/README.md
+++ b/skills/webpage-reader/README.md
@@ -1,0 +1,79 @@
+# 🌐 webpage-reader
+
+> Extract clean Markdown content from any web page URL, removing navigation, ads, and clutter for token-efficient reading and research.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| Version | 1.0.0 |
+| Author | Eric Andrade |
+| Created | 2026-04-03 |
+| Updated | 2026-04-03 |
+| Platforms | All 8 |
+| Category | Content |
+| Tags | web, extraction, markdown, research, content, defuddle, url |
+| Risk | Low |
+
+## Overview
+
+**webpage-reader** extracts the meaningful content from any web page URL, stripping navigation menus, advertisements, sidebars, cookie banners, and other non-content elements. It produces clean, readable Markdown output optimized for token efficiency.
+
+This skill uses [Defuddle CLI](https://github.com/kepano/defuddle) for extraction and gracefully falls back to standard web fetching when Defuddle is unavailable. It is the recommended way to read individual web pages during research, note-taking, or documentation workflows.
+
+## Features
+
+- Clean Markdown extraction from any public HTTP/HTTPS URL
+- Automatic removal of navigation, ads, sidebars, and boilerplate
+- Token-efficient output compared to raw web fetching
+- Save directly to a local file with the `-o` flag
+- Metadata extraction: title, author, description, domain
+- Graceful fallback to WebFetch when Defuddle is not installed
+- Automatic Defuddle installation offer
+- Smart URL routing — redirects `.md`, `.pdf`, `.docx` to the appropriate skills
+- Batch processing for multiple URLs in a single request
+
+## Quick Start
+
+### Triggers
+
+```bash
+# Read a page
+"Read this page: https://example.com/article"
+"Fetch the content of https://docs.example.com"
+"Extract this URL: https://blog.example.com/post"
+"Get this page as Markdown: https://example.com"
+
+# Save to file
+"Extract this article and save it to notes/ref.md: https://example.com/article"
+"Fetch and save this documentation page: https://docs.example.com"
+
+# Metadata only
+"What is the title of this page? https://example.com/post"
+"Who is the author of https://example.com/article?"
+
+# Batch / research
+"Read these three pages and tell me what each covers: [URLs]"
+"Fetch all these documentation URLs for my research: [URLs]"
+"Extract content from these pages and save each one: [URLs]"
+```
+
+## Requirements
+
+Defuddle CLI (the skill offers automatic installation on first use):
+
+```bash
+npm install -g defuddle
+```
+
+Requires Node.js 14+. The skill works without Defuddle via WebFetch fallback, but output quality and token efficiency are reduced.
+
+## Examples
+
+| Request | Action |
+|---------|--------|
+| `"Read https://docs.anthropic.com/..."` | Extracts documentation page as clean Markdown |
+| `"Save this article to notes/ref.md: https://..."` | Extracts and saves to local file |
+| `"Get the title of https://..."` | Returns only the page title from metadata |
+| `"Fetch these 5 URLs for my research"` | Processes each URL sequentially with labeled output |
+| `"Read https://example.com/post without the ads"` | Extracts body content only |

--- a/skills/webpage-reader/SKILL.md
+++ b/skills/webpage-reader/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: webpage-reader
+description: This skill should be used when the user wants to read, fetch, extract, or analyze the content of a web page from a URL. Use when the user provides a URL to access documentation, articles, blog posts, research papers, release notes, or any online content and needs clean, readable Markdown output without navigation clutter, advertisements, or boilerplate HTML.
+license: MIT
+---
+
+## Purpose
+
+This skill extracts clean, readable Markdown from any web page URL by stripping navigation menus, advertisements, sidebars, footers, cookie banners, and all other non-content elements. It produces token-efficient output that focuses exclusively on the meaningful content of the page.
+
+When agents fetch web pages using standard tools, the raw output often includes hundreds of navigation links, promotional widgets, and boilerplate text that consume tokens without adding value. This skill eliminates that noise using Defuddle, a purpose-built content extraction tool, to isolate the article body, documentation text, or main content and return only what matters.
+
+The skill gracefully degrades when Defuddle is not installed: it offers to install it automatically or falls back to standard web fetching with a clear note about the trade-off in output quality and token usage.
+
+This is a **universal skill** — it works in any project, any terminal context, and does not require Obsidian or any specific project structure.
+
+## When to Use
+
+Invoke this skill when:
+
+- The user provides a URL and asks to "read", "fetch", "extract", or "get the content" of a page
+- The user wants to analyze online documentation, API references, or technical guides
+- The user shares a blog post, article, or research paper URL and needs the body content
+- The user wants to save web content to a local Markdown file for offline reference or notes
+- The agent needs to reference external content during a research or writing workflow
+- The user asks to clean up or strip the noise from a page before reading it
+- Multiple URLs are provided for batch processing in a research session
+
+Do NOT use this skill when:
+
+- The URL ends in `.md` — those files are already Markdown, use WebFetch directly instead
+- The URL points to a PDF, DOCX, PPTX, or binary file — use `docling-converter` instead
+- The user needs a multi-source research synthesis with citations — use `deep-research` instead
+- The user needs to interact with the page (forms, logins, JavaScript-heavy apps)
+- The URL requires authentication that the agent cannot provide
+- The user asks to summarize a YouTube video — use `youtube-summarizer` instead
+
+## Workflow
+
+### Step 1: Validate the Input
+
+Before fetching, inspect the URL provided by the user:
+
+1. Verify the input is a valid HTTP or HTTPS URL. If it is not a URL, ask: "Please provide a valid URL starting with http:// or https://."
+2. Check the file extension. Apply these routing rules:
+   - `.md` files → use WebFetch directly (already Markdown, no extraction needed)
+   - `.pdf`, `.docx`, `.pptx`, `.xlsx` files → redirect to `docling-converter`
+   - `.mp3`, `.mp4`, `.wav` files → redirect to `audio-transcriber`
+   - `.png`, `.jpg`, `.gif`, `.svg` files → inform the user that image extraction is not supported
+   - All other URLs → proceed with extraction
+3. If multiple URLs are provided, confirm the count and process each one sequentially.
+
+### Step 2: Check Defuddle Availability
+
+Run a quick availability check before attempting extraction:
+
+```bash
+defuddle --version
+```
+
+If Defuddle is available, proceed to Step 3a.
+
+If Defuddle is not installed, present this offer to the user:
+
+> "Defuddle is not installed. It extracts clean Markdown from web pages with significantly better quality than standard fetching. Install it now with `npm install -g defuddle`? It takes about 10 seconds. (yes/no)"
+
+- If the user confirms: run `npm install -g defuddle`, then proceed to Step 3a.
+- If the user declines: proceed to Step 3b with a note about reduced output quality.
+
+### Step 3a: Extract Content with Defuddle (Preferred Path)
+
+Use Defuddle to extract the page content:
+
+```bash
+# Extract and display as Markdown
+defuddle parse <url> --md
+
+# Extract and save to a file
+defuddle parse <url> --md -o output-filename.md
+
+# Extract specific metadata only
+defuddle parse <url> -p title
+defuddle parse <url> -p description
+defuddle parse <url> -p author
+defuddle parse <url> -p domain
+```
+
+Output format flags:
+
+| Flag | Output | When to use |
+|------|--------|-------------|
+| `--md` | Markdown | Default choice for all content |
+| `--json` | JSON with HTML and Markdown | When structured metadata is needed |
+| (none) | HTML | Avoid — use `--md` instead |
+| `-p <name>` | Single metadata property | When only title, author, or description is needed |
+
+Always prefer `--md` unless the user explicitly requests another format.
+
+### Step 3b: WebFetch Fallback (When Defuddle Is Unavailable)
+
+If Defuddle is not available and the user declined installation, use the standard WebFetch capability with this note prepended to the output:
+
+> Note: Fetching without Defuddle — output may contain navigation elements and non-content text that increases token usage. Install Defuddle with `npm install -g defuddle` for cleaner results.
+
+Apply best-effort cleanup to the WebFetch output:
+- Remove lines that appear to be navigation (very short lines containing only link text)
+- Remove excessive blank lines (collapse to a maximum of two consecutive blank lines)
+- Return the best available content with the caveat clearly noted
+
+### Step 4: Handle Extraction Errors
+
+If the page returns an error or blocks the request, respond with clear guidance:
+
+| Situation | Response |
+|-----------|----------|
+| 403 Forbidden | "This site blocks automated access. Try opening it manually in a browser." |
+| 404 Not Found | "Page not found. Please verify the URL is correct." |
+| Timeout | Retry once automatically; if it fails again, report the timeout |
+| Login required | "This page requires authentication. Log in first and share the content manually." |
+| Paywall detected | "This content is behind a paywall and cannot be extracted automatically." |
+| Empty extraction | Fall back to WebFetch and note the reduced quality |
+| Invalid SSL | Report the SSL error and ask if the user wants to proceed anyway |
+
+Never fabricate or invent page content when extraction fails. Always report failures honestly.
+
+### Step 5: Format and Deliver the Output
+
+Present the extracted content in a consistent format:
+
+```markdown
+# [Page Title]
+
+**Source:** [full URL]
+**Domain:** [domain.com]
+
+---
+
+[Extracted Markdown content]
+```
+
+If saving to a file, confirm the save:
+
+> "Content saved to `[filepath]` — [word count] words extracted from [domain.com]."
+
+If the user requested metadata only (title, author, description), return just the requested fields without the full body content.
+
+For multiple URLs, separate each result with a clear divider and label each section with its source URL.
+
+## Output Formats Reference
+
+Defuddle supports several output modes. Choose the correct one based on what the user needs:
+
+| Mode | Command flag | Output type | Best for |
+|------|-------------|-------------|----------|
+| Markdown | `--md` | Clean `.md` text | Reading articles, documentation, blog posts |
+| JSON | `--json` | JSON with `html` and `markdown` fields | When structured metadata and body are both needed |
+| HTML | (no flag) | Raw cleaned HTML | Avoid — use `--md` for readability |
+| Metadata | `-p <name>` | Single string value | When only title, author, description, or domain is needed |
+
+Available metadata properties via `-p`:
+- `title` — page title
+- `description` — meta description
+- `author` — article author
+- `domain` — domain name only
+- `url` — canonical URL
+
+Always default to `--md` unless the user requests a different format explicitly.
+
+## Integration with Other Skills
+
+This skill works well in combination with others:
+
+- **Before `deep-research`** — use `webpage-reader` to pre-fetch and clean individual pages that will be cited in a research synthesis
+- **Before `obsidian-note-builder`** — extract a URL first, then pass the clean Markdown to `obsidian-note-builder` to create a linked vault note
+- **Before `youtube-summarizer`** — if the user provides a non-YouTube URL for a video page, route to `youtube-summarizer` instead
+- **After `deep-research`** — use `webpage-reader` to fetch individual sources identified during a research session for deeper reading
+
+When chaining skills, always inform the user which skill is handling which step so they understand the workflow.
+
+## Critical Rules
+
+**NEVER:**
+- Use Defuddle to fetch URLs ending in `.md` — WebFetch is correct for Markdown files
+- Fetch binary files (PDFs, images, Office documents) with this skill — redirect to `docling-converter`
+- Fabricate or invent content when extraction fails — always report failures honestly and clearly
+- Strip code blocks, technical content, or preformatted text during output cleanup — preserve all code fences exactly as found
+- Return raw HTML when the user asked for readable content — always use `--md` flag
+- Silently fall back to WebFetch without informing the user about the quality difference
+- Attempt to access URLs behind authentication without clearly telling the user it is not possible
+- Summarize or truncate extracted content unless the user explicitly requests a summary
+
+**ALWAYS:**
+- Check the URL extension before deciding which tool or fallback to use
+- Offer to install Defuddle before falling back to lower-quality extraction
+- Include the source URL in the output so users know where the content came from
+- Preserve the full content without summarizing unless the user explicitly requests a summary
+- Report extraction errors clearly with actionable next steps for the user
+- Process multiple URLs sequentially and label each result clearly with its source URL
+- Confirm file saves with the exact path and an approximate word count
+- Respect the user's choice to decline Defuddle installation and proceed with the WebFetch fallback without repeating the install offer
+
+## Example Usage
+
+### Example 1: Read a documentation page
+
+```
+User: Read this page for me: https://docs.anthropic.com/en/docs/about-claude/models
+```
+
+Action: Check Defuddle availability → run `defuddle parse https://docs.anthropic.com/en/docs/about-claude/models --md` → return clean Markdown of the Claude models page, with source URL noted at the top.
+
+Result: Clean Markdown of the documentation without navigation links, sidebar content, or promotional elements.
+
+---
+
+### Example 2: Save an article to a local file
+
+```
+User: Extract this article and save it to notes/microservices.md:
+      https://martinfowler.com/articles/microservices.html
+```
+
+Action: Run `defuddle parse <url> --md -o notes/microservices.md` → confirm save.
+
+Result: "Content saved to `notes/microservices.md` — 4,200 words extracted from martinfowler.com."
+
+---
+
+### Example 3: Get page metadata only
+
+```
+User: What is the title and author of this page?
+      https://kentcdodds.com/blog/javascript-to-know-for-react
+```
+
+Action: Run `defuddle parse <url> -p title` and `defuddle parse <url> -p author` → return only the two metadata values.
+
+Result: Title and author presented cleanly, without fetching the full body content.
+
+---
+
+### Example 4: Batch extraction for research
+
+```
+User: I am researching LLM evaluation frameworks. Read these three pages:
+      - https://docs.ragas.io/en/latest/
+      - https://www.trulens.org/
+      - https://lilianweng.github.io/posts/2023-03-15-prompt-engineering/
+```
+
+Action: Process each URL sequentially with Defuddle → return three labeled Markdown sections.
+
+Result: Three clean extractions, each starting with its source URL, ready for comparison or summarization.
+
+---
+
+### Example 5: Defuddle not installed — install offer
+
+```
+User: Fetch https://research.google/blog/advances-in-research/ and summarize it
+```
+
+Action: Check `defuddle --version` → not found → present install offer.
+
+Response: "Defuddle is not installed. Install it now with `npm install -g defuddle` for clean Markdown output? (yes/no)"
+
+If the user says yes: install and extract. If no: fall back to WebFetch with a quality note, then proceed with extraction and summarization.

--- a/skills/webpage-reader/evals/evals.json
+++ b/skills/webpage-reader/evals/evals.json
@@ -1,0 +1,72 @@
+{
+  "skill_name": "webpage-reader",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Read this page for me: https://docs.anthropic.com/en/docs/about-claude/models",
+      "expected_output": "Clean Markdown content of the Claude models documentation page with source URL noted",
+      "expectations": [
+        "Output checks for Defuddle availability before proceeding",
+        "Output runs defuddle parse with the --md flag",
+        "Output includes the source URL in the response",
+        "Output contains the main page content as clean Markdown",
+        "Output does not include navigation menus, sidebars, or boilerplate"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Extract this article and save it to notes/microservices.md: https://martinfowler.com/articles/microservices.html",
+      "expected_output": "Markdown content extracted and saved to notes/microservices.md with confirmation message",
+      "expectations": [
+        "Output runs defuddle parse with --md flag and -o notes/microservices.md",
+        "Output confirms the file was saved successfully",
+        "Output includes the file path where content was saved",
+        "Output does not print the full content to the terminal since it was saved to file"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "What is the title and author of this page? https://kentcdodds.com/blog/javascript-to-know-for-react",
+      "expected_output": "Title and author metadata extracted from the page without fetching the full body",
+      "expectations": [
+        "Output uses defuddle with -p title flag",
+        "Output uses defuddle with -p author flag",
+        "Output presents the title and author clearly",
+        "Output does not return the full body content when only metadata was requested"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "I am researching LLM evaluation frameworks. Read these two pages: https://docs.ragas.io/en/latest/ and https://www.trulens.org/",
+      "expected_output": "Clean Markdown content from both pages delivered sequentially with source labels",
+      "expectations": [
+        "Output processes both URLs",
+        "Output extracts each page separately using defuddle",
+        "Output labels each section clearly with its source URL",
+        "Output contains the main content from each page without navigation boilerplate"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Fetch this page but I do not have defuddle installed: https://openai.com/research/gpt-4",
+      "expected_output": "Offer to install Defuddle or fall back to WebFetch with clear explanation of quality difference",
+      "expectations": [
+        "Output detects that defuddle is not installed",
+        "Output offers to install defuddle with npm install -g defuddle",
+        "Output explains the fallback option if the user declines",
+        "Output does not silently fail or fetch without informing the user"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Read https://notes/local-file.md using the webpage-reader skill",
+      "expected_output": "Redirect to WebFetch since the URL ends in .md — no Defuddle needed",
+      "expectations": [
+        "Output recognizes the .md extension",
+        "Output does not use defuddle for .md files",
+        "Output uses WebFetch or reads the file directly instead",
+        "Output explains why Defuddle is not used for this file type"
+      ]
+    }
+  ]
+}

--- a/skills/webpage-reader/evals/trigger-eval.json
+++ b/skills/webpage-reader/evals/trigger-eval.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "webpage-reader",
+  "description": "Triggers for extracting clean Markdown content from web page URLs using Defuddle",
+  "queries": [
+    {"id": 1, "query": "Read this page for me: https://docs.anthropic.com/en/docs/about-claude/models", "should_trigger": true},
+    {"id": 2, "query": "Fetch the content of https://martinfowler.com/articles/microservices.html", "should_trigger": true},
+    {"id": 3, "query": "Extract this URL and give me the article: https://blog.example.com/post", "should_trigger": true},
+    {"id": 4, "query": "Save this documentation page to a file: https://docs.fastapi.tiangolo.com", "should_trigger": true},
+    {"id": 5, "query": "What does this page say? https://openai.com/research/gpt-4", "should_trigger": true},
+    {"id": 6, "query": "Get the content from this website and clean it up: https://example.com/article", "should_trigger": true},
+    {"id": 7, "query": "Read these three URLs for my research session: [list of URLs]", "should_trigger": true},
+    {"id": 8, "query": "Fetch this webpage without all the navigation noise: https://news.ycombinator.com/item?id=123", "should_trigger": true},
+    {"id": 9, "query": "Can you read this article for me? https://medium.com/some-post", "should_trigger": true},
+    {"id": 10, "query": "Extract this documentation page as clean Markdown and save it locally: https://docs.python.org/3/library/json.html", "should_trigger": true},
+    {"id": 11, "query": "Summarize this YouTube video: https://youtube.com/watch?v=abc123", "should_trigger": false},
+    {"id": 12, "query": "Convert this PDF to Markdown: /path/to/document.pdf", "should_trigger": false},
+    {"id": 13, "query": "Transcribe this audio file: meeting.mp3", "should_trigger": false},
+    {"id": 14, "query": "Search the web for information about LLMs and summarize findings", "should_trigger": false},
+    {"id": 15, "query": "Read the README.md file in this repository", "should_trigger": false},
+    {"id": 16, "query": "Open this local file and summarize it: notes/research.md", "should_trigger": false},
+    {"id": 17, "query": "Download and convert this PDF: https://arxiv.org/pdf/2303.08774.pdf", "should_trigger": false},
+    {"id": 18, "query": "Help me write a blog post about microservices architecture", "should_trigger": false},
+    {"id": 19, "query": "Translate this paragraph from Portuguese to English", "should_trigger": false},
+    {"id": 20, "query": "Create a Mermaid diagram from this process description", "should_trigger": false}
+  ]
+}

--- a/skills_index.json
+++ b/skills_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated": "2026-03-20T07:15:36.091917Z",
+  "generated": "2026-04-03T14:55:13.345896Z",
   "skills": [
     {
       "name": "abx-strategy",
@@ -212,35 +212,6 @@
       "triggers": []
     },
     {
-      "name": "document-converter",
-      "version": "1.0.0",
-      "description": "This skill should be used when the user needs to convert documents between formats (Office to PDF, PDF to images, image to PDF), perform PDF operations (merge, split, rotate, encrypt, decrypt), or run OCR on scanned documents. Uses local free tools — LibreOffice, ghostscript, pdftk, tesseract, and imagemagick — with no API key required.",
-      "category": "content",
-      "tags": [
-        "document-conversion",
-        "pdf",
-        "office",
-        "libreoffice",
-        "ocr",
-        "ghostscript",
-        "pdftk",
-        "imagemagick",
-        "tesseract"
-      ],
-      "risk": "safe",
-      "platforms": [
-        "GitHub Copilot CLI",
-        "Claude Code",
-        "OpenAI Codex",
-        "OpenCode",
-        "Gemini CLI",
-        "Antigravity",
-        "Cursor IDE",
-        "AdaL CLI"
-      ],
-      "triggers": []
-    },
-    {
       "name": "cover-letter-generator",
       "version": "2.1.0",
       "description": "This skill should be used when the user needs to create a personalized, compelling cover letter from a resume and job description. Use when writing job application letters, addressing specific role requirements, handling career change narratives, or structuring persuasive arguments for candidacy.",
@@ -342,6 +313,56 @@
         "Antigravity",
         "Cursor IDE",
         "AdaL CLI"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "document-converter",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to convert documents between formats (Office to PDF, PDF to images, image to PDF), perform PDF operations (merge, split, rotate, encrypt, decrypt), or run OCR on scanned documents. Uses local free tools \u2014 LibreOffice, ghostscript, pdftk, tesseract, and imagemagick \u2014 with no API key required. Trigger when the user says \"convert this document\", \"export to PDF\", \"merge PDFs\", \"split PDF\", \"rotate PDF\", \"OCR this scan\", \"convert PPTX to PDF\", \"convert DOCX to PDF\", or any document format conversion request.",
+      "category": "content",
+      "tags": [
+        "document-conversion",
+        "pdf",
+        "office",
+        "libreoffice",
+        "ocr",
+        "ghostscript",
+        "pdftk",
+        "imagemagick",
+        "tesseract"
+      ],
+      "risk": "safe",
+      "platforms": [
+        "GitHub Copilot CLI",
+        "Claude Code",
+        "OpenAI Codex",
+        "OpenCode",
+        "Gemini CLI",
+        "Antigravity",
+        "Cursor IDE",
+        "AdaL CLI"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "excalidraw-diagram",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to create a diagram using Excalidraw \u2014 a hand-drawn style whiteboard tool. Use when the user wants a sketch-style architecture diagram, system design, concept map, user flow, or any visual that benefits from the informal, freehand aesthetic of Excalidraw. Outputs an embedded Excalidraw file ready for use in Obsidian or standalone.",
+      "category": "Content / Visualization",
+      "tags": [
+        "excalidraw",
+        "diagram",
+        "whiteboard",
+        "architecture",
+        "sketch",
+        "obsidian"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
       ],
       "triggers": []
     },
@@ -500,6 +521,149 @@
         "Antigravity",
         "Cursor IDE",
         "AdaL CLI"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "mermaid-diagram",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to create, edit, or convert a diagram into Mermaid syntax. Use when the user asks for a flowchart, sequence diagram, class diagram, state diagram, entity-relationship diagram, mindmap, Gantt chart, or any other diagram type that Mermaid supports. Outputs a ready-to-render Mermaid code block.",
+      "category": "Content / Visualization",
+      "tags": [
+        "mermaid",
+        "diagram",
+        "flowchart",
+        "sequence",
+        "visualization",
+        "obsidian"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-automation",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user wants to automate repetitive Obsidian tasks using the Obsidian CLI, shell commands, or scripted workflows. Use when the user needs to batch-create notes, bulk-update frontmatter, run vault maintenance tasks, open specific notes in Obsidian, navigate the vault programmatically, or integrate Obsidian with external tools.",
+      "category": "Tools Needed",
+      "tags": [
+        "obsidian",
+        "automation",
+        "cli",
+        "scripting",
+        "shell",
+        "batch-processing"
+      ],
+      "risk": "Medium (file system operations)",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-canvas",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to create or edit an Obsidian Canvas \u2014 a freeform visual workspace that arranges notes, cards, links, images, and web content on an infinite canvas. Use when the user wants to map ideas spatially, build a knowledge dashboard, sketch a concept cluster, or create a visual workspace linking multiple Obsidian notes.",
+      "category": "Obsidian / Knowledge Management",
+      "tags": [
+        "obsidian",
+        "canvas",
+        "visual-workspace",
+        "knowledge-map",
+        "dashboard"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-frontmatter",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to create, validate, standardize, or repair YAML frontmatter properties in Obsidian notes. Use when the user wants to add or update tags, aliases, dates, custom properties, or any metadata fields in the Properties panel of an Obsidian note.",
+      "category": "Obsidian / Knowledge Management",
+      "tags": [
+        "obsidian",
+        "frontmatter",
+        "yaml",
+        "properties",
+        "metadata",
+        "dataview"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-links",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user needs to create, validate, repair, or analyze wikilinks inside an Obsidian vault. Use when the user wants to add links between notes, find broken links, rename a linked note, discover orphaned notes, or build a bidirectional linking structure in Obsidian.",
+      "category": "Obsidian / Knowledge Management",
+      "tags": [
+        "obsidian",
+        "wikilinks",
+        "knowledge-graph",
+        "backlinks",
+        "MOC"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-markdown",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user is working with Obsidian notes and needs to create or edit files using Obsidian Flavored Markdown syntax. Use when the user mentions wikilinks, callouts, embeds, frontmatter properties, tags, block references, or any Obsidian-specific syntax that extends standard Markdown.",
+      "category": "Obsidian",
+      "tags": [
+        "obsidian",
+        "markdown",
+        "wikilinks",
+        "callouts",
+        "frontmatter",
+        "embeds",
+        "vault"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "All 8"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "obsidian-note-builder",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user wants to create a well-structured, richly linked Obsidian note from raw content, ideas, or instructions. Use when the user needs entity extraction, automatic wikilink insertion, Zettelkasten-style atomic note formatting, or building a note that integrates seamlessly into an existing vault's knowledge graph.",
+      "category": "Obsidian / Knowledge Management",
+      "tags": [
+        "obsidian",
+        "note-building",
+        "zettelkasten",
+        "knowledge-graph",
+        "entity-extraction"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "Claude Code",
+        "GitHub Copilot",
+        "All AI CLI tools"
       ],
       "triggers": []
     },
@@ -1151,6 +1315,26 @@
         "Antigravity",
         "Cursor IDE",
         "AdaL CLI"
+      ],
+      "triggers": []
+    },
+    {
+      "name": "webpage-reader",
+      "version": "1.0.0",
+      "description": "This skill should be used when the user wants to read, fetch, extract, or analyze the content of a web page from a URL. Use when the user provides a URL to access documentation, articles, blog posts, research papers, release notes, or any online content and needs clean, readable Markdown output without navigation clutter, advertisements, or boilerplate HTML.",
+      "category": "Content",
+      "tags": [
+        "web",
+        "extraction",
+        "markdown",
+        "research",
+        "content",
+        "defuddle",
+        "url"
+      ],
+      "risk": "Low",
+      "platforms": [
+        "All 8"
       ],
       "triggers": []
     },


### PR DESCRIPTION
## Summary

Adds 9 new skills (55 total, up from 46) and all associated metadata updates.

## New Skills

### Content Processing
- **webpage-reader** — extract clean Markdown from URLs using the Defuddle CLI
- **mermaid-diagram** — generate 12 Mermaid diagram types from natural language descriptions
- **excalidraw-diagram** — create hand-drawn style diagrams in Excalidraw JSON format

### Obsidian Knowledge Management (new category)
- **obsidian-markdown** — complete Obsidian Flavored Markdown reference (wikilinks, callouts, embeds, block IDs)
- **obsidian-links** — create, validate, repair, and analyze wikilinks in Obsidian vaults
- **obsidian-frontmatter** — YAML properties lifecycle: create, validate, standardize, repair
- **obsidian-automation** — automate vault tasks via CLI, shell scripts, and Local REST API
- **obsidian-note-builder** — build knowledge-graph-ready notes with entity extraction and Zettelkasten patterns
- **obsidian-canvas** — generate freeform `.canvas` visual workspaces

## Changes

- New `obsidian` bundle (6 skills), extended `content` (+3) and `research` (+1) bundles
- Fixed `validate-skill-yaml.sh` false positive on YAML code examples in SKILL.md body
- Updated `CATALOG.md`, `skills_index.json` (55 skills), `bundles.json`, `docs/bundles/bundles.md`
- Updated `README.md`, `CLAUDE.md`, `CHANGELOG.md`, `cli-installer/README.md`
- Updated `.claude-plugin/plugin.json` and `marketplace.json` to v1.22.0

## After Merge

Push the version tag to trigger npm publish:
```bash
git checkout main && git pull origin main
git tag v1.22.0
git push origin v1.22.0
```