### PR TITLE
fix: add cli installer main entrypoint

### DIFF
--- a/cli-installer/lib/index.js
+++ b/cli-installer/lib/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  detector: require('./detector'),
+  interactive: require('./interactive'),
+  cleanup: require('./cleanup'),
+  copilot: require('./copilot'),
+  claude: require('./claude'),
+  codex: require('./codex'),
+  opencode: require('./opencode'),
+  gemini: require('./gemini'),
+  antigravity: require('./antigravity'),
+  cursor: require('./cursor'),
+  adal: require('./adal'),
+  bundles: require('./bundles'),
+  search: require('./search'),
+  cowork: require('./cowork'),
+  mcpInstaller: require('./mcp-installer'),
+  downloader: require('./core/downloader'),
+  pathResolver: require('./utils/path-resolver'),
+  skillDiff: require('./utils/skill-diff'),
+  skillVersions: require('./utils/skill-versions')
+};

--- a/cli-installer/package.json
+++ b/cli-installer/package.json
@@ -7,7 +7,7 @@
     "claude-superskills": "bin/cli.js"
   },
   "scripts": {
-    "test": "echo '✅ claude-superskills - test passed'",
+    "test": "node -e \"const pkg = require('./'); if (!pkg.detector || typeof pkg.detector.detectTools !== 'function') throw new Error('main entrypoint smoke test failed'); console.log('✅ claude-superskills - test passed')\"",
     "build": "cd .. && ./scripts/build-skills.sh",
     "prebuild": "cd .. && ./scripts/build-skills.sh",
     "link": "npm link",


### PR DESCRIPTION
## Summary
- add the missing `cli-installer/lib/index.js` file referenced by the published package `main` field
- export the existing installer modules through a side-effect-free CommonJS entrypoint
- update `npm test` so it smoke-tests the package main entrypoint instead of only echoing success

## Reproduction
`claude-superskills@2.0.8` currently declares `main: lib/index.js`, but the npm tarball does not include that file. In a clean install, both root loads fail before any CLI usage:

```sh
npm install claude-superskills@2.0.8 --ignore-scripts --no-audit --no-fund
node -e "require('claude-superskills')"
node --input-type=module -e "await import('claude-superskills')"
```

## Validation
- `npm ci --ignore-scripts --no-audit --no-fund`
- `npm test`
- `npm pack --dry-run --json --ignore-scripts` confirms `lib/index.js` is included
- installed the packed tarball into a clean temp project and verified both `require('claude-superskills')` and `import('claude-superskills')` succeed
- `git diff --check`
